### PR TITLE
Derive payment scheme from phone number when none is specified - SER-1991

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'com.github.joschi.jackson:jackson-datatype-threetenbp:2.6.4'
     implementation "org.springdoc:springdoc-openapi-ui:1.6.11"
     implementation 'org.projectlombok:lombok:1.18.22'
+    implementation 'com.googlecode.libphonenumber:carrier:1.206'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,3 +101,6 @@ redis:
     enabled: false
     keyFormat: "clientCorrelationId_tenant_api"
     apiList: "/channel/transfer,/channel/collection,/channel/gsma/transaction,/channel/transactionRequest"
+
+# Maps the network provider to the payment scheme
+payment-schemes: '{"safaricom": "mpesa", "mtn": "momo", "airtel": "airtel"}'


### PR DESCRIPTION
## Description

When no payment scheme is explicitly set in the request header, the client's phone number (whether airtel, mtn, safaricom, etc) in the request body will be used to figure out which flow to start. 
