### PR TITLE
HOTFIX - Use zeebe client 8.1.x to resolve issue with logs not showing up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.apache.camel.springboot:camel-jackson-starter:3.12.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
     implementation 'org.json:json:20211205'
-    implementation 'io.camunda:zeebe-client-java:8.2.29'
+    implementation 'io.camunda:zeebe-client-java:8.1.9'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'


### PR DESCRIPTION
## Description

The previous upgrade to zeebe client 8.2.29 seemed to have affected the display of application logs. It had some dependencies that led to the slf4j warning below:
`SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.`

This resulted in no application logs showing up at all. Using zeebe client 8.1.9 fixes this issue.