### PR TITLE
Add Support for Squad & Monnify POS Transactions - CP-3559

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 
+## OAF Version 1.2.0-mifos-1.5.4
+        * [CP-3559] Add support for handling Squad & Monnify POS transactions
+
 ## OAF Version 1.1.7-mifos-1.5.4
         * [CP-3556] Add support for dynamic callback URLs in transaction requests
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@ repositories {
     }
 
     maven {
-        url = uri('https://secure-api.oneacrefund.org/s3/artifacts')
+        url = uri('https://mifos.jfrog.io/artifactory/phee-gradle-local')
     }
 }
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'org.mifos:ph-ee-connector-common:1.4.1-SNAPSHOT'
+    implementation 'org.mifos:ph-ee-connector-common:1.4.1-gazelle'
     implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.12.0'
     implementation('org.springframework.boot:spring-boot-starter-web:2.6.2')
     implementation('org.springframework.boot:spring-boot-starter-actuator:2.6.2')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.logging.level=warn
-version=1.1.7-mifos-1.5.4
+version=1.2.0-mifos-1.5.4

--- a/src/main/java/org/mifos/connector/channel/api/definition/MonnifyTransactionsApi.java
+++ b/src/main/java/org/mifos/connector/channel/api/definition/MonnifyTransactionsApi.java
@@ -8,8 +8,18 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_SIGNATURE_HEADER;
 
+/**
+ * API definition for processing Monnify transactions.
+ */
 public interface MonnifyTransactionsApi {
 
+    /**
+     * Processes a Monnify transaction.
+     *
+     * @param signature SHA 512 HMAC signature of the request body, generated using the secret key.
+     * @param body      JSON body of the request containing monnify transaction details.
+     * @return {@link ResponseEntity} containing {@link MonnifyTransactionResponse}.
+     */
     @PostMapping("/monnify/transactions")
     ResponseEntity<MonnifyTransactionResponse> processTransaction(@RequestHeader(value = MONNIFY_SIGNATURE_HEADER) String signature,
                                                                   @RequestBody String body);

--- a/src/main/java/org/mifos/connector/channel/api/definition/MonnifyTransactionsApi.java
+++ b/src/main/java/org/mifos/connector/channel/api/definition/MonnifyTransactionsApi.java
@@ -1,0 +1,16 @@
+package org.mifos.connector.channel.api.definition;
+
+import org.mifos.connector.channel.model.MonnifyTransactionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_SIGNATURE_HEADER;
+
+public interface MonnifyTransactionsApi {
+
+    @PostMapping("/monnify/transactions")
+    ResponseEntity<MonnifyTransactionResponse> processTransaction(@RequestHeader(value = MONNIFY_SIGNATURE_HEADER) String signature,
+                                                                  @RequestBody String body);
+}

--- a/src/main/java/org/mifos/connector/channel/api/definition/SquadTransactionsApi.java
+++ b/src/main/java/org/mifos/connector/channel/api/definition/SquadTransactionsApi.java
@@ -8,8 +8,18 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
 
+/**
+ * API definition for processing squad transactions.
+ */
 public interface SquadTransactionsApi {
 
+    /**
+     * Processes a Squad POS transaction.
+     *
+     * @param signature SHA 512 HMAC signature of the request body, generated using the secret key.
+     * @param body      JSON body of the request containing squad transaction details.
+     * @return {@link ResponseEntity} containing {@link SquadTransactionResponse}.
+     */
     @PostMapping("/squad/transactions")
     ResponseEntity<SquadTransactionResponse> processTransaction(@RequestHeader(value = SQUAD_SIGNATURE_HEADER) String signature,
                                                         @RequestBody String body);

--- a/src/main/java/org/mifos/connector/channel/api/definition/SquadTransactionsApi.java
+++ b/src/main/java/org/mifos/connector/channel/api/definition/SquadTransactionsApi.java
@@ -1,0 +1,16 @@
+package org.mifos.connector.channel.api.definition;
+
+import org.mifos.connector.channel.model.SquadTransactionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
+
+public interface SquadTransactionsApi {
+
+    @PostMapping("/squad/transactions")
+    ResponseEntity<SquadTransactionResponse> processTransaction(@RequestHeader(value = SQUAD_SIGNATURE_HEADER) String signature,
+                                                        @RequestBody String body);
+}

--- a/src/main/java/org/mifos/connector/channel/api/implementation/MonnifyTransactionsApiController.java
+++ b/src/main/java/org/mifos/connector/channel/api/implementation/MonnifyTransactionsApiController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_SIGNATURE_HEADER;
 
+/**
+ * Controller for handling Monnify transactions.
+ */
 @RestController
 public class MonnifyTransactionsApiController implements MonnifyTransactionsApi {
 

--- a/src/main/java/org/mifos/connector/channel/api/implementation/MonnifyTransactionsApiController.java
+++ b/src/main/java/org/mifos/connector/channel/api/implementation/MonnifyTransactionsApiController.java
@@ -1,0 +1,34 @@
+package org.mifos.connector.channel.api.implementation;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.mifos.connector.channel.api.definition.MonnifyTransactionsApi;
+import org.mifos.connector.channel.model.MonnifyTransactionResponse;
+import org.mifos.connector.channel.utils.Headers;
+import org.mifos.connector.channel.utils.SpringWrapperUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_SIGNATURE_HEADER;
+
+@RestController
+public class MonnifyTransactionsApiController implements MonnifyTransactionsApi {
+
+    private final ProducerTemplate producerTemplate;
+
+    public MonnifyTransactionsApiController(ProducerTemplate producerTemplate) {
+        this.producerTemplate = producerTemplate;
+    }
+
+    @Override
+    public ResponseEntity<MonnifyTransactionResponse> processTransaction(String signature, String body) {
+        Exchange exchange = SpringWrapperUtil.getDefaultWrappedExchange(producerTemplate.getCamelContext(),
+            new Headers.HeaderBuilder()
+                .addHeader(MONNIFY_SIGNATURE_HEADER, signature)
+                .build(), body);
+        producerTemplate.send("direct:monnify-transaction-base", exchange);
+        int statusCode = exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class);
+        MonnifyTransactionResponse response = exchange.getIn().getBody(MonnifyTransactionResponse.class);
+        return ResponseEntity.status(statusCode).body(response);
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
+++ b/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
 
+/**
+ * Controller for handling Squad transactions.
+ */
 @RestController
 public class SquadTransactionsApiController implements SquadTransactionsApi {
 

--- a/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
+++ b/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
@@ -1,0 +1,35 @@
+package org.mifos.connector.channel.api.implementation;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.mifos.connector.channel.api.definition.SquadTransactionsApi;
+import org.mifos.connector.channel.model.SquadTransactionResponse;
+import org.mifos.connector.channel.utils.Headers;
+import org.mifos.connector.channel.utils.SpringWrapperUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
+
+@RestController
+public class SquadTransactionsApiController implements SquadTransactionsApi {
+
+    private final ProducerTemplate producerTemplate;
+
+    public SquadTransactionsApiController(ProducerTemplate producerTemplate) {
+        this.producerTemplate = producerTemplate;
+    }
+
+    @Override
+    public ResponseEntity<SquadTransactionResponse> processTransaction(String signature, String body) {
+        Headers headers = new Headers.HeaderBuilder()
+            .addHeader(SQUAD_SIGNATURE_HEADER, signature)
+            .build();
+        Exchange exchange = SpringWrapperUtil.getDefaultWrappedExchange(producerTemplate.getCamelContext(),
+            headers, body);
+        producerTemplate.send("direct:squad-transaction-base", exchange);
+        int statusCode = exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class);
+        SquadTransactionResponse response = exchange.getIn().getBody(SquadTransactionResponse.class);
+        return ResponseEntity.status(statusCode).body(response);
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/connector/channel/camel/config/CamelProperties.java
@@ -10,4 +10,9 @@ public class CamelProperties {
     public static final String CLIENTCORRELATIONID = "X-CorrelationID";
     public static final String BATCH_ID_HEADER = "X-BatchID";
     public static final String PAYMENT_SCHEME_HEADER = "X-Payment-Scheme";
+    public static final String SQUAD_SIGNATURE_HEADER = "x-squad-signature";
+    public static final String SQUAD_PROVIDER_NAME = "squad";
+    public static final String HMAC_SHA512 = "HmacSHA512";
+    public static final String MONNIFY_SIGNATURE_HEADER = "monnify-signature";
+    public static final String MONNIFY_PROVIDER_NAME = "monnify";
 }

--- a/src/main/java/org/mifos/connector/channel/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/connector/channel/camel/config/CamelProperties.java
@@ -15,4 +15,5 @@ public class CamelProperties {
     public static final String HMAC_SHA512 = "HmacSHA512";
     public static final String MONNIFY_SIGNATURE_HEADER = "monnify-signature";
     public static final String MONNIFY_PROVIDER_NAME = "monnify";
+    public static final String AMS_ID_VALUE_PLACEHOLDER = "000000";
 }

--- a/src/main/java/org/mifos/connector/channel/camel/routes/MonnifyRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/MonnifyRouteBuilder.java
@@ -1,0 +1,121 @@
+package org.mifos.connector.channel.camel.routes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.bean.validator.BeanValidationException;
+import org.mifos.connector.channel.exception.InvalidSignatureException;
+import org.mifos.connector.channel.model.LiteChannelRequest;
+import org.mifos.connector.channel.model.MonnifyProps;
+import org.mifos.connector.channel.model.MonnifyTransactionRequest;
+import org.mifos.connector.channel.model.MonnifyTransactionResponse;
+import org.mifos.connector.channel.zeebe.ZeebeProcessStarter;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
+import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_SIGNATURE_HEADER;
+import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_PROVIDER_NAME;
+import static org.mifos.connector.channel.utils.PosPaymentUtils.isValidSignature;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMOUNT;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMS;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.CURRENCY;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.EXTERNAL_ID;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.IS_NOTIFICATIONS_FAILURE_ENABLED;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.IS_NOTIFICATIONS_SUCCESS_ENABLED;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.PAYMENT_SCHEME;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.TRANSACTION_ID;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.VIRTUAL_ACCOUNT_NUMBER;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.WEBHOOK_PAYLOAD;
+
+/**
+ * Camel route builder for handling Monnify payment transactions.
+ */
+@Component
+@Slf4j
+public class MonnifyRouteBuilder extends RouteBuilder {
+    private final ZeebeProcessStarter zeebeProcessStarter;
+    private final ObjectMapper objectMapper;
+    private final MonnifyProps monnifyProps;
+
+    public MonnifyRouteBuilder(ZeebeProcessStarter zeebeProcessStarter, MonnifyProps monnifyProps, ObjectMapper objectMapper) {
+        this.zeebeProcessStarter = zeebeProcessStarter;
+        this.objectMapper = objectMapper;
+        this.monnifyProps = monnifyProps;
+    }
+
+    @Override
+    public void configure() throws Exception {
+
+        onException(BeanValidationException.class).handled(true).process(exchange -> {
+            BeanValidationException exception = exchange.getProperty(Exchange.EXCEPTION_CAUGHT,
+                BeanValidationException.class);
+            Map<String, String> errors = new HashMap<>();
+            exception.getConstraintViolations().forEach(violation -> {
+                errors.put(violation.getPropertyPath().toString(), violation.getMessage());
+            });
+            String transactionRef = exchange.getProperty(TRANSACTION_ID, String.class);
+            exchange.getIn().setBody(MonnifyTransactionResponse.builder().transactionReference(transactionRef).errors(errors).build());
+            exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 400);
+        });
+
+        onException(InvalidSignatureException.class).handled(true).process(exchange -> {
+            String transactionRef = exchange.getProperty(TRANSACTION_ID, String.class);
+            exchange.getIn().setBody(MonnifyTransactionResponse.builder().transactionReference(transactionRef)
+                .message("Invalid payload signature").build());
+            exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 400);
+        });
+
+        onException(Exception.class).handled(true).log(LoggingLevel.ERROR, "Caught exception: ${exception.stacktrace}")
+            .process(exchange -> {
+                String transactionRef = exchange.getProperty(TRANSACTION_ID, String.class);
+                exchange.getIn().setBody(MonnifyTransactionResponse.builder().transactionReference(transactionRef)
+                    .message("Error occurred while handling the request").build());
+                exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 500);
+            });
+
+        from("direct:monnify-transaction-base")
+            .id("monnify-transaction-base")
+            .log("Received monnify transaction request: ${body}")
+            .setProperty(WEBHOOK_PAYLOAD, simple("${body}"))
+            .unmarshal().json(MonnifyTransactionRequest.class)
+            .to("bean-validator:monnify-txn-validator")
+            .setProperty(TRANSACTION_ID, simple("${body.eventData.transactionReference}"))
+            .to("direct:monnify-signature-validation")
+            .process(exchange -> {
+                MonnifyTransactionRequest request = exchange.getIn().getBody(MonnifyTransactionRequest.class);
+                String transactionReference = request.getEventData().getTransactionReference();
+                Map<String, Object> variables = new HashMap<>();
+                variables.put(PAYMENT_SCHEME, SQUAD_PROVIDER_NAME);
+                variables.put(WEBHOOK_PAYLOAD, exchange.getProperty(WEBHOOK_PAYLOAD));
+                variables.put(EXTERNAL_ID, transactionReference);
+                variables.put(AMS, monnifyProps.getAmsValue());
+                variables.put(CURRENCY, request.getEventData().getCurrency());
+                variables.put(AMOUNT, request.getEventData().getAmountPaid());
+                variables.put(VIRTUAL_ACCOUNT_NUMBER, request.getEventData().getPaymentReference());
+                variables.put(IS_NOTIFICATIONS_SUCCESS_ENABLED, monnifyProps.isSuccessNotificationsEnabled());
+                variables.put(IS_NOTIFICATIONS_FAILURE_ENABLED, monnifyProps.isFailureNotificationsEnabled());
+                LiteChannelRequest channelRequest = LiteChannelRequest.fromMonnifyTransactionRequest(request.getEventData(), monnifyProps);
+                String transactionId = zeebeProcessStarter.startZeebeWorkflow(monnifyProps.getFlow(), objectMapper.writeValueAsString(channelRequest), variables);
+                log.info("Started workflow for monnify payment with transaction reference: {} and id: {}", transactionReference, transactionId);
+                exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 200);
+                exchange.getIn().setBody(MonnifyTransactionResponse.builder().transactionReference(transactionReference)
+                    .message("Success").build());
+            });
+
+        from("direct:monnify-signature-validation")
+            .id("monnify-signature-validation")
+            .process(exchange -> {
+                String signature = exchange.getIn().getHeader(MONNIFY_SIGNATURE_HEADER, String.class);
+                String body = exchange.getProperty(WEBHOOK_PAYLOAD, String.class);
+                if (!isValidSignature(signature, monnifyProps.getSecretKey(), body)) {
+                    log.error("Monnify signature validation failed for request: {}. Received signature: {}", body, signature);
+                    throw new InvalidSignatureException();
+                }
+            });
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/camel/routes/MonnifyRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/MonnifyRouteBuilder.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
 import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_SIGNATURE_HEADER;
-import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_PROVIDER_NAME;
+import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_PROVIDER_NAME;
 import static org.mifos.connector.channel.utils.PosPaymentUtils.isValidSignature;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMOUNT;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMS;
@@ -90,7 +90,7 @@ public class MonnifyRouteBuilder extends RouteBuilder {
                 MonnifyTransactionRequest request = exchange.getIn().getBody(MonnifyTransactionRequest.class);
                 String transactionReference = request.getEventData().getTransactionReference();
                 Map<String, Object> variables = new HashMap<>();
-                variables.put(PAYMENT_SCHEME, SQUAD_PROVIDER_NAME);
+                variables.put(PAYMENT_SCHEME, MONNIFY_PROVIDER_NAME);
                 variables.put(WEBHOOK_PAYLOAD, exchange.getProperty(WEBHOOK_PAYLOAD));
                 variables.put(EXTERNAL_ID, transactionReference);
                 variables.put(AMS, monnifyProps.getAmsValue());

--- a/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
@@ -1,0 +1,123 @@
+package org.mifos.connector.channel.camel.routes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.bean.validator.BeanValidationException;
+import org.mifos.connector.channel.exception.InvalidSignatureException;
+import org.mifos.connector.channel.model.LiteChannelRequest;
+import org.mifos.connector.channel.model.SquadProps;
+import org.mifos.connector.channel.model.SquadTransactionRequest;
+import org.mifos.connector.channel.model.SquadTransactionResponse;
+import org.mifos.connector.channel.zeebe.ZeebeProcessStarter;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
+import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_PROVIDER_NAME;
+import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
+import static org.mifos.connector.channel.utils.PosPaymentUtils.isValidSignature;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMOUNT;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMS;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.CURRENCY;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.EXTERNAL_ID;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.IS_NOTIFICATIONS_FAILURE_ENABLED;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.IS_NOTIFICATIONS_SUCCESS_ENABLED;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.PAYMENT_SCHEME;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.TRANSACTION_ID;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.VIRTUAL_ACCOUNT_NUMBER;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.WEBHOOK_PAYLOAD;
+
+/**
+ * Camel route builder for handling Squad payment transactions.
+ */
+@Component
+@Slf4j
+public class SquadRouteBuilder extends RouteBuilder {
+    private final ZeebeProcessStarter zeebeProcessStarter;
+    private final ObjectMapper objectMapper;
+    private final SquadProps squadProps;
+
+    public SquadRouteBuilder(ZeebeProcessStarter zeebeProcessStarter, SquadProps squadProps, ObjectMapper objectMapper) {
+        this.zeebeProcessStarter = zeebeProcessStarter;
+        this.objectMapper = objectMapper;
+        this.squadProps = squadProps;
+    }
+
+    @Override
+    public void configure() throws Exception {
+
+        onException(BeanValidationException.class).handled(true).process(exchange -> {
+            Map<String, String> errors = new HashMap<>();
+            BeanValidationException exception = exchange.getProperty(Exchange.EXCEPTION_CAUGHT,
+                BeanValidationException.class);
+            exception.getConstraintViolations().forEach(violation -> {
+                errors.put(violation.getPropertyPath().toString(), violation.getMessage());
+            });
+            String transactionRef = exchange.getProperty(TRANSACTION_ID, String.class);
+            exchange.getIn().setBody(SquadTransactionResponse.builder().responseCode(400).transactionReference(transactionRef)
+                .responseDescription("Validation failure").errors(errors).build());
+            exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 400);
+        });
+
+        onException(InvalidSignatureException.class).handled(true).process(exchange -> {
+            Map<String, String> errors = new HashMap<>();
+            errors.put("signature", "Invalid payload signature");
+            String transactionRef = exchange.getProperty(TRANSACTION_ID, String.class);
+            exchange.getIn().setBody(SquadTransactionResponse.builder().responseCode(400).transactionReference(transactionRef)
+                .responseDescription("Validation failure").errors(errors).build());
+            exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 400);
+        });
+
+        onException(Exception.class).handled(true).log(LoggingLevel.ERROR, "Caught exception: ${exception.stacktrace}")
+            .process(exchange -> {
+                String transactionRef = exchange.getProperty(TRANSACTION_ID, String.class);
+                exchange.getIn().setBody(SquadTransactionResponse.builder().responseCode(500).transactionReference(transactionRef)
+                    .responseDescription("System malfunction").build());
+                exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 500);
+            });
+
+        from("direct:squad-transaction-base")
+            .id("squad-transaction-base")
+            .log("Received squad transaction request: ${body}")
+            .setProperty(WEBHOOK_PAYLOAD, simple("${body}"))
+            .unmarshal().json(SquadTransactionRequest.class)
+            .to("bean-validator:squad-txn-validator")
+            .setProperty(TRANSACTION_ID, simple("${body.transactionReference}"))
+            .to("direct:squad-signature-validation")
+            .process(exchange -> {
+                SquadTransactionRequest request = exchange.getIn().getBody(SquadTransactionRequest.class);
+                Map<String, Object> variables = new HashMap<>();
+                variables.put(PAYMENT_SCHEME, SQUAD_PROVIDER_NAME);
+                variables.put(WEBHOOK_PAYLOAD, exchange.getProperty(WEBHOOK_PAYLOAD));
+                variables.put(EXTERNAL_ID, request.getTransactionReference());
+                variables.put(AMS, squadProps.getAmsValue());
+                variables.put(CURRENCY, request.getCurrency());
+                variables.put(AMOUNT, request.getPrincipalAmount());
+                variables.put(VIRTUAL_ACCOUNT_NUMBER, request.getVirtualAccountNumber());
+                variables.put(IS_NOTIFICATIONS_SUCCESS_ENABLED, squadProps.isSuccessNotificationsEnabled());
+                variables.put(IS_NOTIFICATIONS_FAILURE_ENABLED, squadProps.isFailureNotificationsEnabled());
+                LiteChannelRequest channelRequest = LiteChannelRequest.fromSquadTransactionRequest(request, squadProps);
+                String transactionId = zeebeProcessStarter.startZeebeWorkflow(squadProps.getFlow(), objectMapper.writeValueAsString(channelRequest), variables);
+                log.info("Started workflow for squad payment with transaction reference: {} and id: {}", request.getTransactionReference(), transactionId);
+                exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 200);
+                exchange.getIn().setBody(SquadTransactionResponse.builder().responseCode(200).transactionReference(request.getTransactionReference())
+                    .responseDescription("Success").build());
+            });
+
+        from("direct:squad-signature-validation")
+            .id("squad-signature-validation")
+            .process(exchange -> {
+                String signature = exchange.getIn().getHeader(SQUAD_SIGNATURE_HEADER, String.class);
+                String body = exchange.getProperty(WEBHOOK_PAYLOAD, String.class);
+                if (!isValidSignature(signature, squadProps.getSecretKey(), body)) {
+                    log.error("Squad signature validation failed for request: {}. Received signature: {}", body, signature);
+                    throw new InvalidSignatureException();
+                }
+            });
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/exception/InvalidSignatureException.java
+++ b/src/main/java/org/mifos/connector/channel/exception/InvalidSignatureException.java
@@ -1,0 +1,7 @@
+package org.mifos.connector.channel.exception;
+
+/**
+ * Exception thrown when a signature is invalid.
+ */
+public class InvalidSignatureException extends RuntimeException {
+}

--- a/src/main/java/org/mifos/connector/channel/model/LiteChannelRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/LiteChannelRequest.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 
+import static org.mifos.connector.channel.camel.config.CamelProperties.AMS_ID_VALUE_PLACEHOLDER;
 import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_PROVIDER_NAME;
 import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_PROVIDER_NAME;
 
@@ -54,7 +55,7 @@ public class LiteChannelRequest {
         PartyIdInfo payerPartyIdInfo = new PartyIdInfo(squadProps.getPayerIdType(), request.getVirtualAccountNumber());
         PartyData payer = new PartyData(payerPartyIdInfo);
 
-        PartyIdInfo payeePartyIdInfo = new PartyIdInfo(squadProps.getAmsIdentifier(), request.getVirtualAccountNumber());
+        PartyIdInfo payeePartyIdInfo = new PartyIdInfo(squadProps.getAmsIdentifier(), AMS_ID_VALUE_PLACEHOLDER);
         PartyData payee = new PartyData(payeePartyIdInfo);
 
         Amount amount = new Amount(request.getPrincipalAmount(), request.getCurrency());
@@ -75,7 +76,7 @@ public class LiteChannelRequest {
         PartyIdInfo payerPartyIdInfo = new PartyIdInfo(monnifyProps.getPayerIdType(), requestData.getPaymentReference());
         PartyData payer = new PartyData(payerPartyIdInfo);
 
-        PartyIdInfo payeePartyIdInfo = new PartyIdInfo(monnifyProps.getAmsIdentifier(), requestData.getPaymentReference());
+        PartyIdInfo payeePartyIdInfo = new PartyIdInfo(monnifyProps.getAmsIdentifier(), AMS_ID_VALUE_PLACEHOLDER);
         PartyData payee = new PartyData(payeePartyIdInfo);
 
         Amount amount = new Amount(requestData.getAmountPaid(), requestData.getCurrency());

--- a/src/main/java/org/mifos/connector/channel/model/LiteChannelRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/LiteChannelRequest.java
@@ -1,0 +1,88 @@
+package org.mifos.connector.channel.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+import static org.mifos.connector.channel.camel.config.CamelProperties.MONNIFY_PROVIDER_NAME;
+import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_PROVIDER_NAME;
+
+/**
+ * DTO representing a lightweight channel request payload.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class LiteChannelRequest {
+    private PartyData payer;
+    private PartyData payee;
+    private Amount amount;
+    private TransactionType transactionType;
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class PartyData {
+        private PartyIdInfo partyIdInfo;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class PartyIdInfo {
+        private String partyIdType;
+        private String partyIdentifier;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Amount {
+        private BigDecimal amount;
+        private String currency;
+    }
+
+    /**
+     * Creates a {@link LiteChannelRequest} from a {@link SquadTransactionRequest}.
+     * @param request {@link SquadTransactionRequest}
+     * @param squadProps {@link SquadProps} containing configuration properties for Squad payments
+     * @return {@link LiteChannelRequest} populated with data from the Squad transaction request
+     */
+    public static LiteChannelRequest fromSquadTransactionRequest(SquadTransactionRequest request, SquadProps squadProps) {
+        PartyIdInfo payerPartyIdInfo = new PartyIdInfo(squadProps.getPayerIdType(), request.getVirtualAccountNumber());
+        PartyData payer = new PartyData(payerPartyIdInfo);
+
+        PartyIdInfo payeePartyIdInfo = new PartyIdInfo(squadProps.getAmsIdentifier(), request.getVirtualAccountNumber());
+        PartyData payee = new PartyData(payeePartyIdInfo);
+
+        Amount amount = new Amount(request.getPrincipalAmount(), request.getCurrency());
+
+        TransactionType transactionType = new TransactionType();
+        transactionType.setScenario(SQUAD_PROVIDER_NAME);
+
+        return new LiteChannelRequest(payer, payee, amount, transactionType);
+    }
+
+    /**
+     * Creates a {@link LiteChannelRequest} from a {@link MonnifyTransactionRequest.EventData}.
+     * @param requestData {@link MonnifyTransactionRequest.EventData} containing transaction details
+     * @param monnifyProps {@link MonnifyProps} containing configuration properties for Monnify payments
+     * @return {@link LiteChannelRequest} populated with data from the Monnify transaction request
+     */
+    public static LiteChannelRequest fromMonnifyTransactionRequest(MonnifyTransactionRequest.EventData requestData, MonnifyProps monnifyProps) {
+        PartyIdInfo payerPartyIdInfo = new PartyIdInfo(monnifyProps.getPayerIdType(), requestData.getPaymentReference());
+        PartyData payer = new PartyData(payerPartyIdInfo);
+
+        PartyIdInfo payeePartyIdInfo = new PartyIdInfo(monnifyProps.getAmsIdentifier(), requestData.getPaymentReference());
+        PartyData payee = new PartyData(payeePartyIdInfo);
+
+        Amount amount = new Amount(requestData.getAmountPaid(), requestData.getCurrency());
+
+        TransactionType transactionType = new TransactionType();
+        transactionType.setScenario(MONNIFY_PROVIDER_NAME);
+
+        return new LiteChannelRequest(payer, payee, amount, transactionType);
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/model/MonnifyProps.java
+++ b/src/main/java/org/mifos/connector/channel/model/MonnifyProps.java
@@ -1,0 +1,18 @@
+package org.mifos.connector.channel.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * DTO for Monnify payment properties.
+ */
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "monnify")
+public class MonnifyProps extends PosPaymentProps {
+}

--- a/src/main/java/org/mifos/connector/channel/model/MonnifyTransactionRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/MonnifyTransactionRequest.java
@@ -1,0 +1,67 @@
+package org.mifos.connector.channel.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * DTO for Monnify transaction request.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MonnifyTransactionRequest {
+    private EventData eventData;
+    private String eventType;
+
+    @Getter
+    @Setter
+    public static class EventData {
+        private Product product;
+
+        @NotBlank
+        private String transactionReference;
+        private String paymentReference;
+        private String paidOn;
+        private String paymentDescription;
+
+        @NotNull
+        private BigDecimal amountPaid;
+        private BigDecimal totalPayable;
+        private OfflineProductInformation offlineProductInformation;
+        private String paymentMethod;
+        private String currency;
+        private BigDecimal settlementAmount;
+        private String paymentStatus;
+
+        @NotNull
+        private Customer customer;
+    }
+
+    @Getter
+    @Setter
+    public static class Product {
+        private String reference;
+        private String type;
+    }
+
+    @Getter
+    @Setter
+    public static class Customer {
+        private String name;
+
+        @NotBlank
+        private String email;
+    }
+
+    @Getter
+    @Setter
+    public static class OfflineProductInformation {
+        private String code;
+        private String type;
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/model/MonnifyTransactionResponse.java
+++ b/src/main/java/org/mifos/connector/channel/model/MonnifyTransactionResponse.java
@@ -1,0 +1,22 @@
+package org.mifos.connector.channel.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+/**
+ * DTO for Monnify transaction response.
+ */
+@Getter
+@Setter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MonnifyTransactionResponse {
+    private String message;
+    private Map<String, String> errors;
+    private String transactionReference;
+
+}

--- a/src/main/java/org/mifos/connector/channel/model/PosPaymentProps.java
+++ b/src/main/java/org/mifos/connector/channel/model/PosPaymentProps.java
@@ -1,0 +1,30 @@
+package org.mifos.connector.channel.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * DTO for Generic POS payment properties.
+ */
+@Getter
+@Setter
+public class PosPaymentProps {
+    @NotBlank
+    private String secretKey;
+
+    @NotBlank
+    private String amsIdentifier;
+
+    @NotBlank
+    private String amsValue;
+    @NotBlank
+    private String payerIdType;
+
+    @NotBlank
+    private String flow;
+
+    private boolean successNotificationsEnabled;
+    private boolean failureNotificationsEnabled;
+}

--- a/src/main/java/org/mifos/connector/channel/model/SquadProps.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadProps.java
@@ -1,0 +1,19 @@
+package org.mifos.connector.channel.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * DTO for Squad payment properties.
+ */
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "squad")
+public class SquadProps extends PosPaymentProps {
+
+}

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionRequest.java
@@ -1,0 +1,69 @@
+package org.mifos.connector.channel.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+/**
+ * DTO for Squad transaction request.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SquadTransactionRequest {
+    @NotBlank
+    @JsonProperty("transaction_reference")
+    private String transactionReference;
+
+    @NotBlank
+    @JsonProperty("virtual_account_number")
+    private String virtualAccountNumber;
+
+    @NotNull
+    @Positive
+    @JsonProperty("principal_amount")
+    private BigDecimal principalAmount;
+
+    @JsonProperty("settled_amount")
+    private BigDecimal settledAmount;
+
+    @JsonProperty("fee_charged")
+    private BigDecimal feeCharged;
+
+    @JsonProperty("transaction_date")
+    private String transactionDate;
+
+    @NotBlank
+    @JsonProperty("customer_identifier")
+    private String customerIdentifier;
+
+    @JsonProperty("transaction_identifier")
+    private String transactionIdentifier;
+    private String remarks;
+    private String currency;
+    private String channel;
+
+    @JsonProperty("sender_name")
+    private String senderName;
+    private Meta meta;
+
+    @JsonProperty("encrypted_body")
+    private String encryptedBody;
+
+    @Getter
+    @Setter
+    public static class Meta {
+
+        @JsonProperty("freeze_transaction_ref")
+        private String freezeTransactionRef;
+
+        @JsonProperty("reason_for_frozen_transaction")
+        private String reasonForFrozenTransaction;
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionResponse.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionResponse.java
@@ -1,0 +1,29 @@
+package org.mifos.connector.channel.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+/**
+ * DTO for Squad transaction response.
+ */
+@Getter
+@Setter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SquadTransactionResponse {
+    @JsonProperty("response_code")
+    private int responseCode;
+
+    @JsonProperty("transaction_reference")
+    private String transactionReference;
+
+    @JsonProperty("response_description")
+    private String responseDescription;
+
+    private Map<String, String> errors;
+}

--- a/src/main/java/org/mifos/connector/channel/utils/PosPaymentUtils.java
+++ b/src/main/java/org/mifos/connector/channel/utils/PosPaymentUtils.java
@@ -1,0 +1,32 @@
+package org.mifos.connector.channel.utils;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.mifos.connector.channel.camel.config.CamelProperties.HMAC_SHA512;
+
+/**
+ * Utility class for POS payment operations.
+ */
+public class PosPaymentUtils {
+    private PosPaymentUtils() {
+    }
+
+    public static boolean isValidSignature(String signature, String secretKey, String payload) throws NoSuchAlgorithmException, InvalidKeyException {
+        if (isBlank(signature) || isBlank(secretKey) || isBlank(payload)) {
+            return false;
+        }
+        byte[] byteKey = secretKey.getBytes(StandardCharsets.UTF_8);
+        SecretKeySpec keySpec = new SecretKeySpec(byteKey, HMAC_SHA512);
+        Mac sha512HMAC = Mac.getInstance(HMAC_SHA512);
+        sha512HMAC.init(keySpec);
+        byte[] macData = sha512HMAC.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        String result = String.format("%040x", new BigInteger(1, macData));
+        return result.equals(signature);
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/channel/zeebe/ZeebeVariables.java
@@ -28,4 +28,11 @@ public class ZeebeVariables {
     public static final String PAYMENT_SCHEME = "paymentScheme";
     public static final String CLIENT_CORRELATION_ID = "clientCorrelationId";
     public static final String CALLBACK_URL = "callbackUrl";
+    public static final String WEBHOOK_PAYLOAD = "webhookPayload";
+    public static final String EXTERNAL_ID = "externalId";
+    public static final String AMOUNT = "amount";
+    public static final String CURRENCY = "currency";
+    public static final String IS_NOTIFICATIONS_SUCCESS_ENABLED = "isNotificationsSuccessEnabled";
+    public static final String IS_NOTIFICATIONS_FAILURE_ENABLED = "isNotificationsFailureEnabled";
+    public static final String VIRTUAL_ACCOUNT_NUMBER = "virtualAccountNumber";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,3 +113,21 @@ redis:
 
 # Maps the network provider to the payment scheme
 payment-schemes: '{"safaricom": "mpesa", "mtn": "momo", "airtel": "airtel"}'
+
+squad:
+  secret-key: abc
+  ams-identifier: FINERACTACCOUNTID
+  ams-value: fineract
+  flow: pos_payment-oaf
+  payer-id-type: VIRTUAL_ACCOUNT_NUMBER
+  success-notifications-enabled: false
+  failure-notifications-enabled: false
+
+monnify:
+  secret-key: xyz
+  ams-identifier: FINERACTACCOUNTID
+  ams-value: fineract
+  flow: pos_payment-oaf
+  payer-id-type: VIRTUAL_ACCOUNT_NUMBER
+  success-notifications-enabled: false
+  failure-notifications-enabled: false


### PR DESCRIPTION
## Description




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for processing Squad and Monnify POS transaction webhooks with signature validation and workflow initiation.
  - Introduced configuration options for Squad and Monnify integrations, including secret keys, AMS identifiers, and notification settings.
- **Documentation**
  - Updated release notes to include version 1.2.0-mifos-1.5.4 and document new Squad and Monnify POS transaction support.
- **Chores**
  - Updated dependency versions and repository URLs to enable new integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->