### PR TITLE
CP-3816 Retrieve missed payments for all the districts and not just one

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 
 ## OAF Version 1.3.1-mifos-1.5.4
-        * [CP-3816] Refactor Squad Reconciliation Service so that its done for all the districts and not just one district
+        * [CP-3816] Refactor Squad Reconciliation so that it's done for all the districts (not just one)
 
 ## OAF Version 1.3.0-mifos-1.5.4
         * [CP-3489] Add support for reconciling missed Squad transactions

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 
+## OAF Version 1.3.1-mifos-1.5.4
+        * [CP-3816] Refactor Squad Reconciliation Service so that its done for all the districts and not just one district
+
 ## OAF Version 1.3.0-mifos-1.5.4
         * [CP-3489] Add support for reconciling missed Squad transactions
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.logging.level=warn
-version=1.3.0-mifos-1.5.4
+version=1.3.1-mifos-1.5.4

--- a/src/main/java/org/mifos/connector/channel/api/definition/SquadTransactionsApi.java
+++ b/src/main/java/org/mifos/connector/channel/api/definition/SquadTransactionsApi.java
@@ -1,10 +1,14 @@
 package org.mifos.connector.channel.api.definition;
 
 import org.mifos.connector.channel.model.SquadTransactionResponse;
+import org.mifos.connector.channel.model.SquadTransactionResponseList;
+import org.mifos.connector.channel.model.SquadTransactionsSyncRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.List;
 
 import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
 
@@ -31,5 +35,5 @@ public interface SquadTransactionsApi {
      * @return {@link ResponseEntity} containing {@link SquadTransactionResponse} with the result of the synchronization.
      */
     @PostMapping("/squad/transactions/sync")
-    ResponseEntity<SquadTransactionResponse> syncTransactions(@RequestBody String body);
+    ResponseEntity<SquadTransactionResponseList> syncTransactions(@RequestBody SquadTransactionsSyncRequest body);
 }

--- a/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
+++ b/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
@@ -49,7 +49,8 @@ public class SquadTransactionsApiController implements SquadTransactionsApi {
 
     @Override
     public ResponseEntity<SquadTransactionResponseList> syncTransactions(SquadTransactionsSyncRequest body) {
-        return ResponseEntity.status(HttpStatus.OK).body(this.squadTransactionService.syncTransactions(body));
+        final var response = this.squadTransactionService.syncTransactions(body);
+        return ResponseEntity.status(response.getResponseCode()).body(response);
     }
 
 

--- a/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
+++ b/src/main/java/org/mifos/connector/channel/api/implementation/SquadTransactionsApiController.java
@@ -1,28 +1,38 @@
 package org.mifos.connector.channel.api.implementation;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.support.DefaultExchange;
 import org.mifos.connector.channel.api.definition.SquadTransactionsApi;
 import org.mifos.connector.channel.model.SquadTransactionResponse;
+import org.mifos.connector.channel.model.SquadTransactionResponseList;
+import org.mifos.connector.channel.model.SquadTransactionsSyncRequest;
+import org.mifos.connector.channel.service.SquadTransactionService;
 import org.mifos.connector.channel.utils.Headers;
 import org.mifos.connector.channel.utils.SpringWrapperUtil;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import static org.mifos.connector.channel.camel.config.CamelProperties.SQUAD_SIGNATURE_HEADER;
 
 /**
  * Controller for handling Squad transactions.
  */
+@Slf4j
+@RequiredArgsConstructor
 @RestController
 public class SquadTransactionsApiController implements SquadTransactionsApi {
 
     private final ProducerTemplate producerTemplate;
+    private final SquadTransactionService squadTransactionService;
 
-    public SquadTransactionsApiController(ProducerTemplate producerTemplate) {
-        this.producerTemplate = producerTemplate;
-    }
 
     @Override
     public ResponseEntity<SquadTransactionResponse> processTransaction(String signature, String body) {
@@ -38,11 +48,9 @@ public class SquadTransactionsApiController implements SquadTransactionsApi {
     }
 
     @Override
-    public ResponseEntity<SquadTransactionResponse> syncTransactions(String body) {
-        DefaultExchange exchange = new DefaultExchange(producerTemplate.getCamelContext());
-        exchange.getIn().setBody(body);
-        producerTemplate.send("direct:squad-transactions-sync", exchange);
-        int statusCode = exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class);
-        return ResponseEntity.status(statusCode).body(exchange.getIn().getBody(SquadTransactionResponse.class));
+    public ResponseEntity<SquadTransactionResponseList> syncTransactions(SquadTransactionsSyncRequest body) {
+        return ResponseEntity.status(HttpStatus.OK).body(this.squadTransactionService.syncTransactions(body));
     }
+
+
 }

--- a/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
@@ -138,7 +138,7 @@ public class SquadRouteBuilder extends RouteBuilder {
                 .removeHeader("*")
                 .setHeader(Exchange.HTTP_METHOD, constant("GET"))
                 .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))
-                .setHeader(AUTHORIZATION, simple("Bearer " + squadProps.getToken()))
+                .setHeader(AUTHORIZATION, simple("Bearer ${header.District-Token}"))
                 .toD(squadProps.getBaseUrl() + squadProps.getLogsEndpoint()
                     + "?page=${exchangeProperty[page]}&perPage=" + squadProps.getLogsPageSize()
                 + "&bridgeEndpoint=true&throwExceptionOnFailure=false")

--- a/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
@@ -141,7 +141,6 @@ public class SquadRouteBuilder extends RouteBuilder {
                 .setHeader(Exchange.HTTP_METHOD, constant("GET"))
                 .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))
                 .setHeader(AUTHORIZATION, simple("Bearer ${exchangeProperty[districtToken]}"))
-                .log( "Squad transactions sync requestjjhhdhdhshsh: ${headers}")
                 .toD(squadProps.getBaseUrl() + squadProps.getLogsEndpoint()
                     + "?page=${exchangeProperty[page]}&perPage=" + squadProps.getLogsPageSize()
                 + "&bridgeEndpoint=true&throwExceptionOnFailure=false")

--- a/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/SquadRouteBuilder.java
@@ -32,6 +32,7 @@ import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMOUNT;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.AMS;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.CORRELATION_ID;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.CURRENCY;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.DISTRICT_TOKEN;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.EXTERNAL_ID;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.IS_MISSED_WEBHOOK_NOTIFICATION;
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.IS_NOTIFICATIONS_FAILURE_ENABLED;
@@ -135,10 +136,12 @@ public class SquadRouteBuilder extends RouteBuilder {
             .setProperty(PAGE, constant(1))
             .setProperty(HAS_MORE, constant(true))
             .loopDoWhile(simple("${exchangeProperty[hasMore]} == true"))
+                .setProperty("districtToken", header(DISTRICT_TOKEN))
                 .removeHeader("*")
                 .setHeader(Exchange.HTTP_METHOD, constant("GET"))
                 .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))
-                .setHeader(AUTHORIZATION, simple("Bearer ${header.District-Token}"))
+                .setHeader(AUTHORIZATION, simple("Bearer ${exchangeProperty[districtToken]}"))
+                .log( "Squad transactions sync requestjjhhdhdhshsh: ${headers}")
                 .toD(squadProps.getBaseUrl() + squadProps.getLogsEndpoint()
                     + "?page=${exchangeProperty[page]}&perPage=" + squadProps.getLogsPageSize()
                 + "&bridgeEndpoint=true&throwExceptionOnFailure=false")

--- a/src/main/java/org/mifos/connector/channel/config/ExecutorConfig.java
+++ b/src/main/java/org/mifos/connector/channel/config/ExecutorConfig.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Executors;
 @Configuration
 public class ExecutorConfig {
 
-    @Value("${executor.thread.pool.size:5}")
+    @Value("${executor.thread-pool-size:5}")
     private int threadPoolSize;
 
     @Bean

--- a/src/main/java/org/mifos/connector/channel/config/ExecutorConfig.java
+++ b/src/main/java/org/mifos/connector/channel/config/ExecutorConfig.java
@@ -1,0 +1,20 @@
+package org.mifos.connector.channel.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Configuration
+public class ExecutorConfig {
+
+    @Value("${executor.thread.pool.size:5}")
+    private int threadPoolSize;
+
+    @Bean
+    public ExecutorService executorService() {
+        return Executors.newFixedThreadPool(threadPoolSize);
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionResponseList.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionResponseList.java
@@ -1,6 +1,7 @@
 package org.mifos.connector.channel.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,5 +15,8 @@ import java.util.List;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SquadTransactionResponseList {
+    @JsonProperty("response_code")
+    private int responseCode;
+
     private List<SquadTransactionResponse> squadTransactionResponses;
 }

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionResponseList.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionResponseList.java
@@ -1,0 +1,18 @@
+package org.mifos.connector.channel.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/** * DTO for Squad transaction response list.
+ */
+@Getter
+@Setter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SquadTransactionResponseList {
+    private List<SquadTransactionResponse> squadTransactionResponses;
+}

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionsSyncRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionsSyncRequest.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 /**
  * DTO for Squad transactions synchronization request.
@@ -13,4 +14,6 @@ import javax.validation.constraints.NotBlank;
 public class SquadTransactionsSyncRequest {
     @NotBlank
     private String correlationId;
+
+    private List<String> districtTokens;
 }

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionsSyncRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionsSyncRequest.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
-import java.util.List;
+import java.util.Map;
 
 /**
  * DTO for Squad transactions synchronization request.
@@ -15,5 +15,5 @@ public class SquadTransactionsSyncRequest {
     @NotBlank
     private String correlationId;
 
-    private List<@NotBlank String> districtTokens;
+    private Map<String, @NotBlank String> districtTokens;
 }

--- a/src/main/java/org/mifos/connector/channel/model/SquadTransactionsSyncRequest.java
+++ b/src/main/java/org/mifos/connector/channel/model/SquadTransactionsSyncRequest.java
@@ -15,5 +15,5 @@ public class SquadTransactionsSyncRequest {
     @NotBlank
     private String correlationId;
 
-    private List<String> districtTokens;
+    private List<@NotBlank String> districtTokens;
 }

--- a/src/main/java/org/mifos/connector/channel/service/SquadTransactionService.java
+++ b/src/main/java/org/mifos/connector/channel/service/SquadTransactionService.java
@@ -1,0 +1,15 @@
+package org.mifos.connector.channel.service;
+
+import org.mifos.connector.channel.model.SquadTransactionResponseList;
+import org.mifos.connector.channel.model.SquadTransactionsSyncRequest;
+
+public interface SquadTransactionService {
+
+    /**
+     * Synchronizes Squad transactions by fetching missed Squad webhook logs and reconciling the transactions.
+     *
+     * @param transactionsSyncRequest JSON request body.
+     * @return {@link SquadTransactionResponseList} with the result of the synchronization.
+     */
+    SquadTransactionResponseList syncTransactions(SquadTransactionsSyncRequest transactionsSyncRequest);
+}

--- a/src/main/java/org/mifos/connector/channel/service/SquadTransactionServiceImpl.java
+++ b/src/main/java/org/mifos/connector/channel/service/SquadTransactionServiceImpl.java
@@ -1,0 +1,75 @@
+package org.mifos.connector.channel.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.support.DefaultExchange;
+import org.mifos.connector.channel.model.SquadTransactionResponse;
+import org.mifos.connector.channel.model.SquadTransactionResponseList;
+import org.mifos.connector.channel.model.SquadTransactionsSyncRequest;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.CORRELATION_ID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SquadTransactionServiceImpl implements SquadTransactionService {
+
+    private final ProducerTemplate producerTemplate;
+    private final ExecutorService executorService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public SquadTransactionResponseList syncTransactions(SquadTransactionsSyncRequest transactionsSyncRequest) {
+        List<Future<SquadTransactionResponse>> futures = new ArrayList<>();
+        final var correlationId = transactionsSyncRequest.getCorrelationId();
+        for (final var districtToken : transactionsSyncRequest.getDistrictTokens()) {
+            futures.add(executorService.submit(() -> syncTransactionsByToken(objectMapper.writeValueAsString(Map.of(CORRELATION_ID, correlationId)), districtToken)));
+        }
+        // Collect results
+        List<SquadTransactionResponse> squadTransactionResponses = new ArrayList<>();
+        for (final var future : futures) {
+            try {
+                squadTransactionResponses.add(future.get());  // Blocking call (waits for task to finish)
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // Restore interrupt status
+                log.error(e.getMessage(), e);
+            } catch (ExecutionException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+        return SquadTransactionResponseList.builder()
+                .squadTransactionResponses(squadTransactionResponses)
+                .build();
+    }
+
+    /** * Sync transactions for a specific district token.
+     *
+     * @param correlationId Correlation ID for the sync request.
+     * @param districtToken District token to identify the district.
+     * @return SquadTransactionResponse containing the sync result.
+     */
+    private SquadTransactionResponse syncTransactionsByToken(String correlationId, String districtToken) {
+        DefaultExchange exchange = new DefaultExchange(producerTemplate.getCamelContext());
+        exchange.getIn().setBody(correlationId);
+        exchange.getIn().setHeader("District-Token", districtToken);
+        producerTemplate.send("direct:squad-transactions-sync", exchange);
+        return exchange.getIn().getBody(SquadTransactionResponse.class);
+    }
+
+    @PreDestroy
+    public void shutdownExecutor() {
+        log.info("Shutting down executor service");
+        executorService.shutdown();
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/service/SquadTransactionServiceImpl.java
+++ b/src/main/java/org/mifos/connector/channel/service/SquadTransactionServiceImpl.java
@@ -17,8 +17,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.mifos.connector.channel.zeebe.ZeebeVariables.CORRELATION_ID;
+import static org.mifos.connector.channel.zeebe.ZeebeVariables.DISTRICT_TOKEN;
 
 @Service
 @Slf4j
@@ -32,10 +34,21 @@ public class SquadTransactionServiceImpl implements SquadTransactionService {
     @Override
     public SquadTransactionResponseList syncTransactions(SquadTransactionsSyncRequest transactionsSyncRequest) {
         List<Future<SquadTransactionResponse>> futures = new ArrayList<>();
+
         final var correlationId = transactionsSyncRequest.getCorrelationId();
+        final String correlationPayloadJson;
+        try {
+                correlationPayloadJson = objectMapper.writeValueAsString(Map.of(CORRELATION_ID, correlationId));
+            } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+               throw new IllegalStateException("Failed to serialize correlation payload", e);
+            }
+
         for (final var districtToken : transactionsSyncRequest.getDistrictTokens()) {
-            futures.add(executorService.submit(() -> syncTransactionsByToken(objectMapper.writeValueAsString(Map.of(CORRELATION_ID, correlationId)), districtToken)));
+            futures.add(executorService.submit(() -> syncTransactionsByToken(correlationPayloadJson, districtToken)));
+
         }
+
+
         // Collect results
         List<SquadTransactionResponse> squadTransactionResponses = new ArrayList<>();
         for (final var future : futures) {
@@ -44,27 +57,57 @@ public class SquadTransactionServiceImpl implements SquadTransactionService {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt(); // Restore interrupt status
                 log.error(e.getMessage(), e);
+                break;
             } catch (ExecutionException e) {
                 log.error(e.getMessage(), e);
             }
         }
         return SquadTransactionResponseList.builder()
+                .responseCode(getGeneralResponseStatus(squadTransactionResponses))
                 .squadTransactionResponses(squadTransactionResponses)
                 .build();
     }
 
     /** * Sync transactions for a specific district token.
      *
-     * @param correlationId Correlation ID for the sync request.
+     * @param correlationPayloadJson Correlation ID for the sync request.
      * @param districtToken District token to identify the district.
      * @return SquadTransactionResponse containing the sync result.
      */
-    private SquadTransactionResponse syncTransactionsByToken(String correlationId, String districtToken) {
+    private SquadTransactionResponse syncTransactionsByToken(String correlationPayloadJson, String districtToken) {
         DefaultExchange exchange = new DefaultExchange(producerTemplate.getCamelContext());
-        exchange.getIn().setBody(correlationId);
-        exchange.getIn().setHeader("District-Token", districtToken);
+        exchange.getIn().setBody(correlationPayloadJson);
+        exchange.getIn().setHeader(DISTRICT_TOKEN, districtToken);
         producerTemplate.send("direct:squad-transactions-sync", exchange);
         return exchange.getIn().getBody(SquadTransactionResponse.class);
+    }
+
+    /**
+     * Determines the general response status based on individual transaction responses.
+     *
+     * @param squadTransactionResponses List of individual SquadTransactionResponse objects.
+     * @return General HTTP status code representing the overall result.
+     */
+    private int getGeneralResponseStatus(List<SquadTransactionResponse> squadTransactionResponses) {
+        final var responseStatuses = squadTransactionResponses.stream()
+                .map(SquadTransactionResponse::getResponseCode)
+                .distinct()
+                .collect(Collectors.toList());
+        int code;
+        if (responseStatuses.isEmpty()) {
+            code = 500; // Internal Server Error if no responses
+        }else if (responseStatuses.size() > 1) {
+            code = 207; // Multi-Status if mixed results
+        } else if (responseStatuses.get(0) >= 200 && responseStatuses.get(0) < 300) {
+            code = responseStatuses.get(0); // All successful
+        } else if (responseStatuses.get(0) >= 400 && responseStatuses.get(0) < 500) {
+            code = responseStatuses.get(0); // All client errors
+        } else if (responseStatuses.get(0) >= 500) {
+            code = responseStatuses.get(0); // All server errors
+        } else {
+            code = 500; // Default to Internal Server Error for unexpected codes
+        }
+        return code;
     }
 
     @PreDestroy

--- a/src/main/java/org/mifos/connector/channel/service/SquadTransactionServiceImpl.java
+++ b/src/main/java/org/mifos/connector/channel/service/SquadTransactionServiceImpl.java
@@ -33,7 +33,7 @@ public class SquadTransactionServiceImpl implements SquadTransactionService {
 
     @Override
     public SquadTransactionResponseList syncTransactions(SquadTransactionsSyncRequest transactionsSyncRequest) {
-        List<Future<SquadTransactionResponse>> futures = new ArrayList<>();
+        final java.util.Map<Future<SquadTransactionResponse>, String> futures = new java.util.LinkedHashMap<>();
 
         final var correlationId = transactionsSyncRequest.getCorrelationId();
         final String correlationPayloadJson;
@@ -43,20 +43,21 @@ public class SquadTransactionServiceImpl implements SquadTransactionService {
                throw new IllegalStateException("Failed to serialize correlation payload", e);
             }
 
-        for (final var districtToken : transactionsSyncRequest.getDistrictTokens()) {
-            futures.add(executorService.submit(() -> syncTransactionsByToken(correlationPayloadJson, districtToken)));
-
+        for (final var districtToken : transactionsSyncRequest.getDistrictTokens().entrySet()) {
+            futures.put(executorService.submit(() -> syncTransactionsByToken(correlationPayloadJson, districtToken.getValue())), districtToken.getKey());
         }
 
 
         // Collect results
         List<SquadTransactionResponse> squadTransactionResponses = new ArrayList<>();
-        for (final var future : futures) {
+        for (final var entry : futures.entrySet()) {
+            final var future = entry.getKey();
+            final var district = entry.getValue();
             try {
                 squadTransactionResponses.add(future.get());  // Blocking call (waits for task to finish)
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt(); // Restore interrupt status
-                log.error(e.getMessage(), e);
+                log.error("Interrupted while syncing district: {}", district, e);
                 break;
             } catch (ExecutionException e) {
                 log.error(e.getMessage(), e);

--- a/src/main/java/org/mifos/connector/channel/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/channel/zeebe/ZeebeVariables.java
@@ -37,4 +37,5 @@ public class ZeebeVariables {
     public static final String VIRTUAL_ACCOUNT_NUMBER = "virtualAccountNumber";
     public static final String IS_MISSED_WEBHOOK_NOTIFICATION = "isMissedWebhookNotification";
     public static final String CORRELATION_ID = "correlationId";
+    public static final String DISTRICT_TOKEN = "District-Token";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -135,3 +135,6 @@ monnify:
   payer-id-type: VIRTUAL_ACCOUNT_NUMBER
   success-notifications-enabled: false
   failure-notifications-enabled: false
+
+executor:
+  thread-pool-size: 5


### PR DESCRIPTION
## Description

* Refactor Squad Reconciliation Service so that we retrieve missed payments for all the districts and not just one

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design related bullet points or design document link related to this PR added in the description above.

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciliation now processes all districts in a single run and accepts multiple district tokens for district-specific sync.

* **Performance**
  * Concurrent processing for faster synchronization; concurrency is configurable (default: 5).

* **API Changes**
  * Sync requests use a structured payload including districtTokens; responses return a list of transaction results with aggregated status codes.

* **Documentation**
  * Added Release Notes entry for OAF v1.3.1-mifos-1.5.4 (CP-3816).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->