### PR TITLE
CP-3817 - Add support for operations app keycloak auth

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 
+## OAF Version 1.4.0-mifos-1.5.4
+        * [CP-3817] Add support for operations app authentication token in transaction requests
+
 ## OAF Version 1.3.0-mifos-1.5.4
         * [CP-3489] Add support for reconciling missed Squad transactions
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.logging.level=warn
-version=1.3.0-mifos-1.5.4
+version=1.4.0-mifos-1.5.4

--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -41,6 +41,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -50,8 +52,8 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Base64.getEncoder;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
 import static org.mifos.connector.channel.camel.config.CamelProperties.*;
@@ -86,7 +88,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     private String transactionRequestFlow;
     private String partyRegistration;
     private String mpesaFlow;
-    private String restAuthHost;
+    private String operationsAuthEndpoint;
     private String operationsUrl;
     private Boolean operationsAuthEnabled;
     private String transfersEndpoint;
@@ -105,13 +107,15 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     private Map<String, String> paymentSchemes;
     private static final String DEFAULT_COLLECTION_PAYMENT_SCHEME = "mpesa";
 
+    public final Map<String, String> tokenCache = new ConcurrentHashMap<>();
+
     public ChannelRouteBuilder(@Value("#{'${dfspids}'.split(',')}") List<String> dfspIds,
                                @Value("${bpmn.flows.payment-transfer}") String paymentTransferFlow,
                                @Value("${bpmn.flows.special-payment-transfer}") String specialPaymentTransferFlow,
                                @Value("${bpmn.flows.transaction-request}") String transactionRequestFlow,
                                @Value("${bpmn.flows.party-registration}") String partyRegistration,
                                @Value("${bpmn.flows.mpesa-flow}") String mpesaFlow,
-                               @Value("${rest.authorization.host}") String restAuthHost,
+                               @Value("${operations.endpoint.auth}") String operationsAuthEndpoint,
                                @Value("${operations.url}") String operationsUrl,
                                @Value("${operations.auth-enabled}") Boolean operationsAuthEnabled,
                                @Value("${operations.endpoint.transfers}") String transfersEndpoint,
@@ -140,7 +144,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
         this.objectMapper = objectMapper;
         this.clientProperties = clientProperties;
         this.restTemplate = restTemplate;
-        this.restAuthHost = restAuthHost;
+        this.operationsAuthEndpoint = operationsAuthEndpoint;
         this.operationsUrl = operationsUrl;
         this.transfersEndpoint = transfersEndpoint;
         this.transactionEndpoint = transactionEndpoint;
@@ -221,15 +225,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                     }
                     Client client = clientProperties.getClient(tenantId);
 
-                    HttpEntity<String> entity = buildHeader(tenantId, null);
-                    if(operationsAuthEnabled){
-                        UriComponentsBuilder builder = buildParams(client);
-                        ResponseEntity<String> exchange = callAuthApi(builder,entity);
-                        JSONObject jsonObject = new JSONObject(exchange.getBody());
-                        String token = jsonObject.getString("access_token");
-
-                        entity = buildHeader(tenantId, token);
-                    }
+                    HttpEntity<MultiValueMap<String, String>> entity = buildHttpEntity(tenantId, client);
 
                     String transactionId = e.getIn().getHeader("transactionId", String.class);
                     ResponseEntity<String> exchange = restTemplate.exchange(operationsUrl + "/transfers?page=0&size=20&transactionId=" + transactionId, HttpMethod.GET, entity, String.class);
@@ -280,20 +276,9 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                         throw new RuntimeException("Requested tenant " + tenantId + " not configured in the connector!");}
                     Client client = clientProperties.getClient(tenantId);
                     String requestType = getRequestType(e.getIn().getHeader("requestType", String.class));
-                    HttpEntity<String> entity = buildHeader(tenantId, null);
-                    ResponseEntity<String> authExchange;
 
-                    if(operationsAuthEnabled){
-                        UriComponentsBuilder builder = buildParams(client);
-                         authExchange = callAuthApi(builder,entity);
-                    }
-                    else {
-                        authExchange = restTemplate.exchange(restAuthHost + "/oauth/token?grant_type=client_credentials", HttpMethod.POST, entity, String.class);
-                    }
+                    HttpEntity<MultiValueMap<String, String>> entity = buildHttpEntity(tenantId, client);
 
-                    JSONObject jsonObject = new JSONObject(authExchange.getBody());
-                    String token = jsonObject.getString("access_token");
-                    entity = buildHeader(tenantId, token);
                     String correlationId = e.getIn().getHeader(CLIENTCORRELATIONID, String.class);
                     ResponseEntity<String> exchange = callOpsTxnApi(requestType,correlationId,entity);
                     JSONArray contents = new JSONObject(exchange.getBody()).getJSONArray("content");
@@ -367,17 +352,19 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                 });
     }
 
-    private ResponseEntity<String> fetchApibyWorkflowKey(HttpEntity<String> entity, long workflowInstanceKey) {
+    private ResponseEntity<String> fetchApibyWorkflowKey(HttpEntity<MultiValueMap<String, String>> entity, long workflowInstanceKey) {
         return restTemplate.exchange(operationsUrl + "/transfer/" +
               workflowInstanceKey, HttpMethod.GET, entity, String.class);
     }
 
-    private ResponseEntity<String> callOpsTxnApi(String requestType, String correlationId, HttpEntity<String> entity) {
+    private ResponseEntity<String> callOpsTxnApi(String requestType, String correlationId, HttpEntity<MultiValueMap<String, String>> entity) {
         return restTemplate.exchange(operationsUrl + requestType +"clientCorrelationId=" +
                 correlationId, HttpMethod.GET, entity, String.class);
     }
 
-    private ResponseEntity<String> callAuthApi(UriComponentsBuilder builder, HttpEntity<String> entity) {
+    private ResponseEntity<String> callAuthApi(UriComponentsBuilder builder, HttpEntity<MultiValueMap<String, String>> entity) {
+        logger.info("builder.toUriString()");
+        logger.info(builder.toUriString());
        return restTemplate.exchange(builder.toUriString(), HttpMethod.POST,
                 entity, String.class);
     }
@@ -766,16 +753,12 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
 
     private UriComponentsBuilder buildParams(Client client) {
         HttpsURLConnection.setDefaultHostnameVerifier((restAuthHost, session) -> true);
-        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(restAuthHost + "/oauth/token")
-                // Add query parameter
-                .queryParam("username", client.getClientId())
-                .queryParam("password", client.getClientSecret())
-                .queryParam("grant_type", "password");
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(operationsAuthEndpoint);
         logger.debug("Builder : {}", builder.toUriString());
         return builder;
     }
 
-    private HttpEntity<String> buildHeader(String tenantId, String token) {
+    public HttpEntity<MultiValueMap<String, String>> buildHeaderAndBody(String tenantId, String token, Client client) {
         HttpHeaders httpHeaders = new HttpHeaders();
         if (token == null) {
             httpHeaders.add("Platform-TenantId", tenantId);
@@ -786,8 +769,12 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
             httpHeaders.remove("Authorization");
             httpHeaders.add("Authorization", "Bearer " + token);
         }
-        HttpEntity<String> entity = new HttpEntity<String>(null, httpHeaders);
-        return entity;
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("username", client.getClientId());
+        body.add("password", client.getClientSecret());
+        body.add("grant_type", "password");
+        body.add("client_id", "paymenthub");
+        return new HttpEntity<>(body, httpHeaders);
     }
 
     private String getCollectionPaymentScheme(String paymentSchemeHeaderValue, String phoneNumber) {
@@ -813,5 +800,24 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                 sanitizedNumber, DEFAULT_COLLECTION_PAYMENT_SCHEME);
         }
         return DEFAULT_COLLECTION_PAYMENT_SCHEME;
+    }
+
+    /**
+     * Build HttpEntity with authorization header using cached token or fetch a new one if not present in cache
+     * @param tenantId tenant id
+     * @param client client details
+     * @return HttpEntity with authorization header
+     */
+    public HttpEntity<MultiValueMap<String, String>> buildHttpEntity(String tenantId, Client client) {
+        String token = tokenCache.get(tenantId);
+        if (token == null) {
+            HttpEntity<MultiValueMap<String, String>> entity = buildHeaderAndBody(tenantId, null, client);
+            UriComponentsBuilder builder = buildParams(client);
+            ResponseEntity<String> authExchange = callAuthApi(builder, entity);
+            JSONObject jsonObject = new JSONObject(authExchange.getBody());
+            token = jsonObject.getString("access_token");
+            tokenCache.put(tenantId, token);
+        }
+        return buildHeaderAndBody(tenantId, token, client);
     }
 }

--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -97,7 +97,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     private String mpesaFlow;
     private String operationsAuthEndpoint;
     private String operationsUrl;
-    private Boolean operationsAuthEnabled;
+    private Long operationsAuthDefaultExpirySeconds;
     private String transfersEndpoint;
     private String transactionEndpoint;
     private Boolean isNotificationSuccessServiceEnabled;
@@ -114,7 +114,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     private Map<String, String> paymentSchemes;
     private static final String DEFAULT_COLLECTION_PAYMENT_SCHEME = "mpesa";
 
-    public final Map<String, String> tokenCache = new ConcurrentHashMap<>();
+    public final Map<String, TokenWithExpiry> tokenCache = new ConcurrentHashMap<>();
 
     public ChannelRouteBuilder(@Value("#{'${dfspids}'.split(',')}") List<String> dfspIds,
                                @Value("${bpmn.flows.payment-transfer}") String paymentTransferFlow,
@@ -124,7 +124,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                                @Value("${bpmn.flows.mpesa-flow}") String mpesaFlow,
                                @Value("${operations.endpoint.auth}") String operationsAuthEndpoint,
                                @Value("${operations.url}") String operationsUrl,
-                               @Value("${operations.auth-enabled}") Boolean operationsAuthEnabled,
+                               @Value("${operations.auth-expiry-default}") Long operationsAuthDefaultExpirySeconds,
                                @Value("${operations.endpoint.transfers}") String transfersEndpoint,
                                @Value("${operations.endpoint.transactionReq}") String transactionEndpoint,
                                @Value("${mpesa.notification.success.enabled}") Boolean isNotificationSuccessServiceEnabled,
@@ -159,7 +159,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
         this.isNotificationFailureServiceEnabled = isNotificationFailureServiceEnabled;
         this.timer = timer;
         this.restAuthHeader = restAuthHeader;
-        this.operationsAuthEnabled = operationsAuthEnabled;
+        this.operationsAuthDefaultExpirySeconds = operationsAuthDefaultExpirySeconds;
     }
 
     @Override
@@ -377,10 +377,11 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     }
 
     private String getRequestType(String requestType) {
-        requestType = requestType.isEmpty() ? "transfers" : requestType;
-        requestType = requestType.equalsIgnoreCase("transfers") ? transfersEndpoint :
-                transactionEndpoint;
-        return requestType;
+        if (org.apache.commons.lang3.StringUtils.isBlank(requestType) ||
+                "transfers".equalsIgnoreCase(requestType)) {
+            return transfersEndpoint;
+        }
+        return transactionEndpoint;
     }
 
     private void collectionRoutes(){
@@ -816,15 +817,17 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
      * @return HttpEntity with authorization header
      */
     public HttpEntity<MultiValueMap<String, String>> buildHttpEntity(String tenantId, Client client) {
-        String token = tokenCache.get(tenantId);
-        if (token == null) {
-            HttpEntity<MultiValueMap<String, String>> entity = buildHeaderAndBody(tenantId, null, client);
+        TokenWithExpiry entry = tokenCache.get(tenantId);
+        if (entry == null || entry.isExpired(operationsAuthDefaultExpirySeconds)) {
+            HttpEntity<MultiValueMap<String, String>> tokenReq = buildHeaderAndBody(tenantId, null, client);
             UriComponentsBuilder builder = buildParams(client);
-            ResponseEntity<String> authExchange = callAuthApi(builder, entity);
-            JSONObject jsonObject = new JSONObject(authExchange.getBody());
-            token = jsonObject.getString("access_token");
-            tokenCache.put(tenantId, token);
+            ResponseEntity<String> authExchange = callAuthApi(builder, tokenReq);
+            JSONObject json = new JSONObject(authExchange.getBody());
+            String accessToken = json.getString("access_token");
+            long expiresIn = json.optLong("expires_in", operationsAuthDefaultExpirySeconds);
+            entry = new TokenWithExpiry(accessToken, java.time.Instant.now().plusSeconds(expiresIn));
+            tokenCache.put(tenantId, entry);
         }
-        return buildHeaderAndBody(tenantId, token, client);
+        return buildHeaderAndBody(tenantId, entry.token, client);
     }
 }

--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -370,8 +370,6 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     }
 
     private ResponseEntity<String> callAuthApi(UriComponentsBuilder builder, HttpEntity<MultiValueMap<String, String>> entity) {
-        logger.info("builder.toUriString()");
-        logger.info(builder.toUriString());
        return restTemplate.exchange(builder.toUriString(), HttpMethod.POST,
                 entity, String.class);
     }

--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -114,6 +114,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     private Map<String, String> paymentSchemes;
     private static final String DEFAULT_COLLECTION_PAYMENT_SCHEME = "mpesa";
     private final TokenCache tokenCache;
+    private final Long operationsAuthExpiryBufferSeconds;
 
     public ChannelRouteBuilder(@Value("#{'${dfspids}'.split(',')}") List<String> dfspIds,
                                @Value("${bpmn.flows.payment-transfer}") String paymentTransferFlow,
@@ -137,7 +138,8 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                                ObjectMapper objectMapper,
                                ClientProperties clientProperties,
                                RestTemplate restTemplate,
-                               TokenCache tokenCache) {
+                               TokenCache tokenCache,
+                               @Value("${operations.auth-expiry-buffer-default}") Long operationsAuthExpiryBufferSeconds) {
         super(authProcessor, authProperties);
         super.configure();
         this.paymentTransferFlow = paymentTransferFlow;
@@ -161,6 +163,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
         this.restAuthHeader = restAuthHeader;
         this.operationsAuthDefaultExpirySeconds = operationsAuthDefaultExpirySeconds;
         this.tokenCache = tokenCache;
+        this.operationsAuthExpiryBufferSeconds = operationsAuthExpiryBufferSeconds;
     }
 
     @Override
@@ -817,7 +820,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
      */
     public HttpEntity<MultiValueMap<String, String>> buildHttpEntity(String tenantId, Client client) {
         TokenWithExpiry entry = tokenCache.getTenantCache(tenantId);
-        if (entry == null || entry.isExpired(operationsAuthDefaultExpirySeconds)) {
+        if (entry == null || entry.isExpired(operationsAuthExpiryBufferSeconds)) {
             HttpEntity<MultiValueMap<String, String>> tokenReq = buildHeaderAndBody(tenantId, null, client);
             UriComponentsBuilder builder = buildParams(client);
             ResponseEntity<String> authExchange = callAuthApi(builder, tokenReq);

--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -51,7 +51,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Spliterators.spliteratorUnknownSize;

--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -19,6 +19,7 @@ import org.mifos.connector.channel.GSMA_API.GsmaP2PResponseDto;
 import org.mifos.connector.channel.camel.config.Client;
 import org.mifos.connector.channel.camel.config.ClientProperties;
 import org.mifos.connector.channel.model.ValidationResponseDTO;
+import org.mifos.connector.channel.operations.TokenCache;
 import org.mifos.connector.channel.utils.AMSProps;
 import org.mifos.connector.channel.utils.AMSUtils;
 import org.mifos.connector.channel.zeebe.ZeebeProcessStarter;
@@ -59,7 +60,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Spliterator;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
@@ -113,8 +113,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
     @Value("#{${payment-schemes}}")
     private Map<String, String> paymentSchemes;
     private static final String DEFAULT_COLLECTION_PAYMENT_SCHEME = "mpesa";
-
-    public final Map<String, TokenWithExpiry> tokenCache = new ConcurrentHashMap<>();
+    private final TokenCache tokenCache;
 
     public ChannelRouteBuilder(@Value("#{'${dfspids}'.split(',')}") List<String> dfspIds,
                                @Value("${bpmn.flows.payment-transfer}") String paymentTransferFlow,
@@ -137,7 +136,8 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                                @Autowired(required = false) AuthProperties authProperties,
                                ObjectMapper objectMapper,
                                ClientProperties clientProperties,
-                               RestTemplate restTemplate) {
+                               RestTemplate restTemplate,
+                               TokenCache tokenCache) {
         super(authProcessor, authProperties);
         super.configure();
         this.paymentTransferFlow = paymentTransferFlow;
@@ -160,6 +160,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
         this.timer = timer;
         this.restAuthHeader = restAuthHeader;
         this.operationsAuthDefaultExpirySeconds = operationsAuthDefaultExpirySeconds;
+        this.tokenCache = tokenCache;
     }
 
     @Override
@@ -815,7 +816,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
      * @return HttpEntity with authorization header
      */
     public HttpEntity<MultiValueMap<String, String>> buildHttpEntity(String tenantId, Client client) {
-        TokenWithExpiry entry = tokenCache.get(tenantId);
+        TokenWithExpiry entry = tokenCache.getTenantCache(tenantId);
         if (entry == null || entry.isExpired(operationsAuthDefaultExpirySeconds)) {
             HttpEntity<MultiValueMap<String, String>> tokenReq = buildHeaderAndBody(tenantId, null, client);
             UriComponentsBuilder builder = buildParams(client);
@@ -824,7 +825,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
             String accessToken = json.getString("access_token");
             long expiresIn = json.optLong("expires_in", operationsAuthDefaultExpirySeconds);
             entry = new TokenWithExpiry(accessToken, java.time.Instant.now().plusSeconds(expiresIn));
-            tokenCache.put(tenantId, entry);
+            tokenCache.updateTenantCache(tenantId, entry);
         }
         return buildHeaderAndBody(tenantId, entry.token, client);
     }

--- a/src/main/java/org/mifos/connector/channel/camel/routes/TokenWithExpiry.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/TokenWithExpiry.java
@@ -1,0 +1,17 @@
+package org.mifos.connector.channel.camel.routes;
+
+import java.time.Instant;
+
+public class TokenWithExpiry {
+    final String token;
+    final java.time.Instant expiresAt;
+
+    TokenWithExpiry(String token, java.time.Instant expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired(long bufferSeconds) {
+        return Instant.now().isAfter(expiresAt.minusSeconds(bufferSeconds));
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/camel/routes/TokenWithExpiry.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/TokenWithExpiry.java
@@ -3,10 +3,10 @@ package org.mifos.connector.channel.camel.routes;
 import java.time.Instant;
 
 public class TokenWithExpiry {
-    final String token;
+    public final String token;
     final java.time.Instant expiresAt;
 
-    TokenWithExpiry(String token, java.time.Instant expiresAt) {
+    public TokenWithExpiry(String token, java.time.Instant expiresAt) {
         this.token = token;
         this.expiresAt = expiresAt;
     }

--- a/src/main/java/org/mifos/connector/channel/operations/TokenCache.java
+++ b/src/main/java/org/mifos/connector/channel/operations/TokenCache.java
@@ -1,0 +1,30 @@
+package org.mifos.connector.channel.operations;
+
+import org.mifos.connector.channel.camel.routes.TokenWithExpiry;
+import org.springframework.stereotype.Component;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class TokenCache {
+
+    private final Map<String, TokenWithExpiry> cache = new ConcurrentHashMap<>();
+
+    public void updateTenantCache(String tenantId, TokenWithExpiry token) {
+        cache.put(tenantId, token);
+    }
+
+    public TokenWithExpiry getTenantCache(String tenantId) {
+        return cache.get(tenantId);
+    }
+
+    public boolean isExpired(String tenantId, long bufferSeconds) {
+        TokenWithExpiry token = cache.get(tenantId);
+        return token == null || token.isExpired(bufferSeconds);
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+}
+

--- a/src/main/resources/application-bb.yml
+++ b/src/main/resources/application-bb.yml
@@ -1,5 +1,5 @@
 operations:
-  url: "http://bb-operations.mifos.io/api/v1"
+  url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
 
 identity:
   channel:

--- a/src/main/resources/application-bb.yml
+++ b/src/main/resources/application-bb.yml
@@ -1,7 +1,7 @@
 operations:
   url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
   auth-expiry-default: ${AUTHENTICATION_EXPIRY_DEFAULT:60} # in seconds
-  auth-expiry-buffer-default: ${AUTHENTICATION_EXPIRY_BUFFER_DEFAULT:60} # in seconds
+  auth-expiry-buffer-default: ${AUTHENTICATION_EXPIRY_BUFFER_DEFAULT:30} # in seconds
   endpoint:
     auth: ${AUTHENTICATION_API:https://accounts.qa.oneacrefund.org/realms/OneAcreFund/protocol/openid-connect/token}
     transfers: "/transfers?page=0&size=1&"

--- a/src/main/resources/application-bb.yml
+++ b/src/main/resources/application-bb.yml
@@ -1,6 +1,7 @@
 operations:
   url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
   auth-expiry-default: ${AUTHENTICATION_EXPIRY_DEFAULT:60} # in seconds
+  auth-expiry-buffer-default: ${AUTHENTICATION_EXPIRY_BUFFER_DEFAULT:60} # in seconds
   endpoint:
     auth: ${AUTHENTICATION_API:https://accounts.qa.oneacrefund.org/realms/OneAcreFund/protocol/openid-connect/token}
     transfers: "/transfers?page=0&size=1&"

--- a/src/main/resources/application-bb.yml
+++ b/src/main/resources/application-bb.yml
@@ -1,5 +1,10 @@
 operations:
   url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
+  auth-expiry-default: ${AUTHENTICATION_EXPIRY_DEFAULT:60} # in seconds
+  endpoint:
+    auth: ${AUTHENTICATION_API:https://accounts.qa.oneacrefund.org/realms/OneAcreFund/protocol/openid-connect/token}
+    transfers: "/transfers?page=0&size=1&"
+    transactionReq: "/transactionRequests/?"
 
 identity:
   channel:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ server:
 
 operations:
   url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
-  auth-enabled: true
+  auth-expiry-default: ${AUTHENTICATION_EXPIRY_DEFAULT:60} # in seconds
   endpoint:
     auth: ${AUTHENTICATION_API:https://accounts.qa.oneacrefund.org/realms/OneAcreFund/protocol/openid-connect/token}
     transfers: "/transfers?page=0&size=1&"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,9 +23,10 @@ server:
   port: 8080
 
 operations:
-  url: "http://bb-operations.mifos.io/api/v1"
-  auth-enabled: false
+  url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
+  auth-enabled: true
   endpoint:
+    auth: ${AUTHENTICATION_API:https://accounts.qa.oneacrefund.org/realms/OneAcreFund/protocol/openid-connect/token}
     transfers: "/transfers?page=0&size=1&"
     transactionReq: "/transactionRequests/?"
 

--- a/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mifos.connector.channel.camel.config.Client;
 import org.mifos.connector.channel.camel.config.ClientProperties;
 import org.mifos.connector.channel.camel.routes.ChannelRouteBuilder;
+import org.mifos.connector.channel.camel.routes.TokenWithExpiry;
 import org.springframework.http.*;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -39,7 +40,7 @@ class ChannelRouteBuilderTest {
                 "mpesaFlow",
                 "http://authhost",
                 "http://opsurl",
-                true,
+                60L,
                 "/transfers",
                 "/transactionReq",
                 true,
@@ -58,7 +59,7 @@ class ChannelRouteBuilderTest {
 
     @Test
     void testBuildHttpEntity_TokenCached() {
-        routeBuilder.tokenCache.put("tenant1", "cachedToken");
+        routeBuilder.tokenCache.put("tenant1", new TokenWithExpiry("cachedToken", System.currentTimeMillis() + 60000));
         HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
         assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer cachedToken"));
     }

--- a/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
@@ -1,0 +1,108 @@
+package org.mifos.connector.channel;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mifos.connector.channel.camel.config.Client;
+import org.mifos.connector.channel.camel.config.ClientProperties;
+import org.mifos.connector.channel.camel.routes.ChannelRouteBuilder;
+import org.springframework.http.*;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ChannelRouteBuilderTest {
+
+    private ChannelRouteBuilder routeBuilder;
+    private RestTemplate restTemplate;
+    private ClientProperties clientProperties;
+    private Client client;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        clientProperties = mock(ClientProperties.class);
+        client = mock(Client.class);
+        when(client.getClientId()).thenReturn("testClientId");
+        when(client.getClientSecret()).thenReturn("testClientSecret");
+
+        routeBuilder = new ChannelRouteBuilder(
+                Collections.singletonList("tenant1"),
+                "paymentTransferFlow",
+                "specialPaymentTransferFlow",
+                "transactionRequestFlow",
+                "partyRegistration",
+                "mpesaFlow",
+                "http://authhost",
+                "http://opsurl",
+                true,
+                "/transfers",
+                "/transactionReq",
+                true,
+                true,
+                "timer",
+                "Basic testheader",
+                null,
+                null,
+                null,
+                null,
+                null,
+                clientProperties,
+                restTemplate
+        );
+    }
+
+    @Test
+    void testBuildHttpEntity_TokenCached() {
+        routeBuilder.tokenCache.put("tenant1", "cachedToken");
+        HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
+        assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer cachedToken"));
+    }
+
+    @Test
+    void testBuildHttpEntity_TokenNotCached() {
+        when(client.getClientId()).thenReturn("id");
+        when(client.getClientSecret()).thenReturn("secret");
+
+        ResponseEntity<String> responseEntity = new ResponseEntity<>(
+                new JSONObject().put("access_token", "newToken").toString(),
+                HttpStatus.OK
+        );
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(responseEntity);
+
+        HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
+        assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer newToken"));
+        assertEquals("newToken", routeBuilder.tokenCache.get("tenant1"));
+    }
+
+    @Test
+    void testBuildHeaderAndBody_NoToken() {
+        HttpEntity<MultiValueMap<String, String>> entity = routeBuilder.buildHeaderAndBody("tenant1", null, client);
+        HttpHeaders headers = entity.getHeaders();
+        assertEquals("tenant1", headers.getFirst("Platform-TenantId"));
+        assertEquals("Basic testheader", headers.getFirst("Authorization"));
+        MultiValueMap<String, String> body = entity.getBody();
+        assertEquals("testClientId", body.getFirst("username"));
+        assertEquals("testClientSecret", body.getFirst("password"));
+        assertEquals("password", body.getFirst("grant_type"));
+        assertEquals("paymenthub", body.getFirst("client_id"));
+    }
+
+    @Test
+    void testBuildHeaderAndBody_WithToken() {
+        HttpEntity<MultiValueMap<String, String>> entity = routeBuilder.buildHeaderAndBody("tenant1", "myToken", client);
+        HttpHeaders headers = entity.getHeaders();
+        assertEquals("tenant1", headers.getFirst("Platform-TenantId"));
+        assertEquals("Bearer myToken", headers.getFirst("Authorization"));
+        MultiValueMap<String, String> body = entity.getBody();
+        assertEquals("testClientId", body.getFirst("username"));
+        assertEquals("testClientSecret", body.getFirst("password"));
+        assertEquals("password", body.getFirst("grant_type"));
+        assertEquals("paymenthub", body.getFirst("client_id"));
+    }
+}

--- a/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
@@ -7,6 +7,7 @@ import org.mifos.connector.channel.camel.config.Client;
 import org.mifos.connector.channel.camel.config.ClientProperties;
 import org.mifos.connector.channel.camel.routes.ChannelRouteBuilder;
 import org.mifos.connector.channel.camel.routes.TokenWithExpiry;
+import org.mifos.connector.channel.operations.TokenCache;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -27,6 +28,7 @@ class ChannelRouteBuilderTest {
     private RestTemplate restTemplate;
     private ClientProperties clientProperties;
     private Client client;
+    private final TokenCache tokenCache = new TokenCache();
 
     @BeforeEach
     void setUp() {
@@ -58,13 +60,14 @@ class ChannelRouteBuilderTest {
                 null,
                 null,
                 clientProperties,
-                restTemplate
+                restTemplate,
+                tokenCache
         );
     }
 
     @Test
     void testBuildHttpEntity_TokenCached() {
-        routeBuilder.tokenCache.put("tenant1", new TokenWithExpiry("cachedToken", Instant.now().plusSeconds(600)));
+        tokenCache.updateTenantCache("tenant1", new TokenWithExpiry("cachedToken", Instant.now().plusSeconds(600)));
         HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
         assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer cachedToken"));
     }
@@ -83,7 +86,7 @@ class ChannelRouteBuilderTest {
 
         HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
         assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer newToken"));
-        assertEquals("newToken", routeBuilder.tokenCache.get("tenant1").token);
+        assertEquals("newToken", tokenCache.getTenantCache("tenant1").token);
     }
 
     @Test

--- a/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
@@ -7,10 +7,15 @@ import org.mifos.connector.channel.camel.config.Client;
 import org.mifos.connector.channel.camel.config.ClientProperties;
 import org.mifos.connector.channel.camel.routes.ChannelRouteBuilder;
 import org.mifos.connector.channel.camel.routes.TokenWithExpiry;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -59,7 +64,7 @@ class ChannelRouteBuilderTest {
 
     @Test
     void testBuildHttpEntity_TokenCached() {
-        routeBuilder.tokenCache.put("tenant1", new TokenWithExpiry("cachedToken", System.currentTimeMillis() + 60000));
+        routeBuilder.tokenCache.put("tenant1", new TokenWithExpiry("cachedToken", Instant.now().plusSeconds(600)));
         HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
         assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer cachedToken"));
     }
@@ -78,7 +83,7 @@ class ChannelRouteBuilderTest {
 
         HttpEntity<?> entity = routeBuilder.buildHttpEntity("tenant1", client);
         assertTrue(entity.getHeaders().get("Authorization").get(0).contains("Bearer newToken"));
-        assertEquals("newToken", routeBuilder.tokenCache.get("tenant1"));
+        assertEquals("newToken", routeBuilder.tokenCache.get("tenant1").token);
     }
 
     @Test

--- a/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/channel/ChannelRouteBuilderTest.java
@@ -61,7 +61,8 @@ class ChannelRouteBuilderTest {
                 null,
                 clientProperties,
                 restTemplate,
-                tokenCache
+                tokenCache,
+                30L
         );
     }
 

--- a/src/test/java/org/mifos/connector/channel/TokenCacheTest.java
+++ b/src/test/java/org/mifos/connector/channel/TokenCacheTest.java
@@ -1,0 +1,56 @@
+package org.mifos.connector.channel;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mifos.connector.channel.camel.routes.TokenWithExpiry;
+import org.mifos.connector.channel.operations.TokenCache;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenCacheTest {
+
+    private TokenCache tokenCache;
+
+    @BeforeEach
+    void setUp() {
+        tokenCache = new TokenCache();
+    }
+
+    @Test
+    void testUpdateAndGetTenantCache() {
+        TokenWithExpiry token = new TokenWithExpiry("token123", Instant.now().plusSeconds(60));
+        tokenCache.updateTenantCache("tenantA", token);
+        TokenWithExpiry cached = tokenCache.getTenantCache("tenantA");
+        assertNotNull(cached);
+        assertEquals("token123", cached.token);
+    }
+
+    @Test
+    void testIsExpired_TrueWhenExpired() {
+        TokenWithExpiry expiredToken = new TokenWithExpiry("expired", Instant.now().minusSeconds(10));
+        tokenCache.updateTenantCache("tenantB", expiredToken);
+        assertTrue(tokenCache.isExpired("tenantB", 0));
+    }
+
+    @Test
+    void testIsExpired_FalseWhenNotExpired() {
+        TokenWithExpiry validToken = new TokenWithExpiry("valid", Instant.now().plusSeconds(100));
+        tokenCache.updateTenantCache("tenantC", validToken);
+        assertFalse(tokenCache.isExpired("tenantC", 0));
+    }
+
+    @Test
+    void testIsExpired_TrueWhenNoToken() {
+        assertTrue(tokenCache.isExpired("unknownTenant", 0));
+    }
+
+    @Test
+    void testClear() {
+        tokenCache.updateTenantCache("tenantD", new TokenWithExpiry("token", Instant.now().plusSeconds(60)));
+        tokenCache.clear();
+        assertNull(tokenCache.getTenantCache("tenantD"));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transaction requests now use per-tenant cached operations-app authentication tokens for authenticated calls.

- **Configuration**
  - Operations URL and auth endpoint can be overridden via OPERATIONS_URL and AUTHENTICATION_API env vars.
  - Added configurable auth expiry and expiry-buffer (seconds).

- **Documentation**
  - Added release notes entry for OAF version 1.3.1-mifos-1.5.4 including relevant change IDs.

- **Tests**
  - Added unit tests covering token retrieval, caching, expiry, and authenticated request construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->