### PR TITLE
feat: Add zeebe health checks on readiness

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,4 +34,3 @@ Release Notes
 ## OAF Version 1.1.2-mifos-1.5.3
         * [SER-2040] - Fix login issue in get transfer status route when authentication with operation apps is enabled
         * [SER-2040] - Add support of client name and custom data fields in the valiadtion response
-        * [SER-2304] - Add more transaction logs

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 
+## OAF Version 1.3.3-mifos-1.5.4
+        * [CP-3614] - Add Zeebe Connectivity Check to the Channel connector Health Endpoint
 
 ## OAF Version 1.3.2-mifos-1.5.4
         * [CP-3725] - Add support for mutiple tenants in Payment Hub Ops

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.logging.level=warn
-version=1.3.2-mifos-1.5.4
+version=1.3.3-mifos-1.5.4

--- a/src/main/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicator.java
+++ b/src/main/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicator.java
@@ -1,0 +1,66 @@
+package org.mifos.connector.channel.camel.config;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.Topology;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+@RequiredArgsConstructor
+@Component("zeebe")
+public class ZeebeHealthIndicator implements HealthIndicator {
+
+    private final ZeebeClient zeebeClient;
+    private final AtomicReference<Health> cachedHealth = new AtomicReference<>();
+    private final AtomicLong lastCheckTime = new AtomicLong(0);
+    @Value("${zeebe-custom.health.cache-duration-ms:15000}")
+    private long cacheDurationMs;
+    @Value("${zeebe-custom.health.check-timeout-seconds:5}")
+    private long healthCheckTimeoutSeconds;
+
+    @Override
+    public Health health() {
+        long now = System.currentTimeMillis();
+        long lastCheck = lastCheckTime.get();
+
+        // Return cached result if still fresh
+        Health cached = cachedHealth.get();
+
+        // Return cached result if still fresh
+        if (cached != null && (now - lastCheck) < cacheDurationMs) {
+            return cached;
+        }
+
+        // Perform actual check with timeout
+        try {
+
+            Topology topology = zeebeClient.newTopologyRequest()
+                    .send().get(healthCheckTimeoutSeconds, TimeUnit.SECONDS);
+
+            cached = Health.up()
+                    .withDetail("brokers", topology.getBrokers().size())
+                    .withDetail("clusterSize", topology.getClusterSize())
+                    .withDetail("partitions", topology.getPartitionsCount())
+                    .build();
+
+        } catch (TimeoutException e) {
+            cached = Health.down()
+                    .withDetail("error", "Zeebe health check timed out after " + healthCheckTimeoutSeconds + "s")
+                    .build();
+        } catch (Exception e) {
+            cached = Health.down()
+                    .withDetail("error", e.getClass().getSimpleName() + ": " + e.getMessage())
+                    .build();
+        }
+
+        lastCheck = now;
+        return cached;
+    }
+}

--- a/src/main/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicator.java
+++ b/src/main/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicator.java
@@ -52,6 +52,11 @@ public class ZeebeHealthIndicator implements HealthIndicator {
             newHealth = Health.down()
                     .withDetail("error", "Zeebe health check timed out after " + healthCheckTimeoutSeconds + "s")
                     .build();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            newHealth = Health.down()
+                    .withDetail("error", "Zeebe health check interrupted")
+                    .build();
         } catch (Exception e) {
             newHealth = Health.down()
                     .withDetail("error", e.getClass().getSimpleName() + ": " + e.getMessage())

--- a/src/main/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicator.java
+++ b/src/main/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicator.java
@@ -32,35 +32,35 @@ public class ZeebeHealthIndicator implements HealthIndicator {
 
         // Return cached result if still fresh
         Health cached = cachedHealth.get();
-
-        // Return cached result if still fresh
         if (cached != null && (now - lastCheck) < cacheDurationMs) {
             return cached;
         }
 
         // Perform actual check with timeout
+        Health newHealth;
         try {
-
             Topology topology = zeebeClient.newTopologyRequest()
                     .send().get(healthCheckTimeoutSeconds, TimeUnit.SECONDS);
 
-            cached = Health.up()
+            newHealth = Health.up()
                     .withDetail("brokers", topology.getBrokers().size())
                     .withDetail("clusterSize", topology.getClusterSize())
                     .withDetail("partitions", topology.getPartitionsCount())
                     .build();
 
         } catch (TimeoutException e) {
-            cached = Health.down()
+            newHealth = Health.down()
                     .withDetail("error", "Zeebe health check timed out after " + healthCheckTimeoutSeconds + "s")
                     .build();
         } catch (Exception e) {
-            cached = Health.down()
+            newHealth = Health.down()
                     .withDetail("error", e.getClass().getSimpleName() + ": " + e.getMessage())
                     .build();
         }
 
-        lastCheck = now;
-        return cached;
+        cachedHealth.set(newHealth);
+        lastCheckTime.set(now);
+
+        return newHealth;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 camel:
-  server-port: 5001
+  server-port: 5000
   springboot:
     main-run-controller: true
   dataformat:
@@ -20,7 +20,7 @@ mpesa:
 timer: "PT45S"
 
 server:
-  port: 8081
+  port: 8080
 
 operations:
   url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 camel:
-  server-port: 5000
+  server-port: 5001
   springboot:
     main-run-controller: true
   dataformat:
@@ -20,11 +20,12 @@ mpesa:
 timer: "PT45S"
 
 server:
-  port: 8080
+  port: 8081
 
 operations:
   url: ${OPERATIONS_URL:http://bb-operations.mifos.io/api/v1}
   auth-expiry-default: ${AUTHENTICATION_EXPIRY_DEFAULT:60} # in seconds
+  auth-expiry-buffer-default: ${AUTHENTICATION_EXPIRY_BUFFER_DEFAULT:30} # in seconds
   endpoint:
     auth: ${AUTHENTICATION_API:https://accounts.qa.oneacrefund.org/realms/OneAcreFund/protocol/openid-connect/token}
     transfers: "/transfers?page=0&size=1&"
@@ -100,10 +101,12 @@ management:
     health:
       probes:
         enabled: true
-      liveness:
-        enabled: true
-      readiness:
-        enabled: true
+      group:
+        readiness:
+          include: readinessState,zeebe
+        liveness:
+          include: livenessState
+      show-details: ALWAYS
 logging:
   level:
     root: INFO
@@ -155,3 +158,8 @@ monnify:
 
 executor:
   thread-pool-size: 5
+
+zeebe-custom:
+  health:
+    cache-duration-ms: 15000
+    check-timeout-seconds: 5

--- a/src/test/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicatorTest.java
+++ b/src/test/java/org/mifos/connector/channel/camel/config/ZeebeHealthIndicatorTest.java
@@ -1,0 +1,220 @@
+package org.mifos.connector.channel.camel.config;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.Topology;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ZeebeHealthIndicatorTest {
+
+    @Mock
+    private ZeebeClient zeebeClient;
+
+    @Mock
+    private TopologyRequestStep1 topologyRequestStep1;
+
+    @Mock
+    private ZeebeFuture<Topology> zeebeFuture;
+
+    @Mock
+    private Topology topology;
+
+    @Mock
+    private BrokerInfo brokerInfo;
+
+    private ZeebeHealthIndicator healthIndicator;
+
+    private static final long CACHE_DURATION_MS = 15000;
+    private static final long HEALTH_CHECK_TIMEOUT_SECONDS = 5;
+
+    @BeforeEach
+    void setUp() {
+        healthIndicator = new ZeebeHealthIndicator(zeebeClient);
+        ReflectionTestUtils.setField(healthIndicator, "cacheDurationMs", CACHE_DURATION_MS);
+        ReflectionTestUtils.setField(healthIndicator, "healthCheckTimeoutSeconds", HEALTH_CHECK_TIMEOUT_SECONDS);
+    }
+
+    @Test
+    void health_shouldReturnUp_whenZeebeIsHealthy() throws Exception {
+        // Given
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(topology);
+        when(topology.getBrokers()).thenReturn(Collections.singletonList(brokerInfo));
+        when(topology.getClusterSize()).thenReturn(3);
+        when(topology.getPartitionsCount()).thenReturn(6);
+
+        // When
+        Health health = healthIndicator.health();
+
+        // Then
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("brokers", 1);
+        assertThat(health.getDetails()).containsEntry("clusterSize", 3);
+        assertThat(health.getDetails()).containsEntry("partitions", 6);
+
+        verify(zeebeClient).newTopologyRequest();
+        verify(topologyRequestStep1).send();
+        verify(zeebeFuture).get(HEALTH_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void health_shouldReturnDown_whenTopologyRequestTimesOut() throws Exception {
+        // Given
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS)))
+                .thenThrow(new TimeoutException("Timeout"));
+
+        // When
+        Health health = healthIndicator.health();
+
+        // Then
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("error");
+        assertThat(health.getDetails().get("error").toString())
+                .contains("timed out after " + HEALTH_CHECK_TIMEOUT_SECONDS + "s");
+
+        verify(zeebeClient).newTopologyRequest();
+    }
+
+    @Test
+    void health_shouldReturnDown_whenTopologyRequestThrowsException() throws Exception {
+        // Given
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS)))
+                .thenThrow(new RuntimeException("Connection failed"));
+
+        // When
+        Health health = healthIndicator.health();
+
+        // Then
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("error");
+        assertThat(health.getDetails().get("error").toString())
+                .contains("RuntimeException")
+                .contains("Connection failed");
+
+        verify(zeebeClient).newTopologyRequest();
+    }
+
+    @Test
+    void health_shouldReturnCachedResult_whenCalledWithinCacheDuration() throws Exception {
+        // Given
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(topology);
+        when(topology.getBrokers()).thenReturn(Collections.singletonList(brokerInfo));
+        when(topology.getClusterSize()).thenReturn(3);
+        when(topology.getPartitionsCount()).thenReturn(6);
+
+        // When - First call
+        Health firstHealth = healthIndicator.health();
+
+        // When - Second call immediately after (within cache duration)
+        Health secondHealth = healthIndicator.health();
+
+        // Then
+        assertThat(firstHealth.getStatus()).isEqualTo(Status.UP);
+        assertThat(secondHealth.getStatus()).isEqualTo(Status.UP);
+        assertThat(firstHealth).isSameAs(secondHealth); // Same cached instance
+
+        // Verify Zeebe was only called once
+        verify(zeebeClient, times(1)).newTopologyRequest();
+        verify(zeebeFuture, times(1)).get(anyLong(), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void health_shouldMakeNewRequest_whenCacheExpires() throws Exception {
+        // Given
+        ReflectionTestUtils.setField(healthIndicator, "cacheDurationMs", 100L); // 100ms cache
+
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(topology);
+        when(topology.getBrokers()).thenReturn(Collections.singletonList(brokerInfo));
+        when(topology.getClusterSize()).thenReturn(3);
+        when(topology.getPartitionsCount()).thenReturn(6);
+
+        // When - First call
+        Health firstHealth = healthIndicator.health();
+
+        // Wait for cache to expire
+        Thread.sleep(150);
+
+        // When - Second call after cache expires
+        Health secondHealth = healthIndicator.health();
+
+        // Then
+        assertThat(firstHealth.getStatus()).isEqualTo(Status.UP);
+        assertThat(secondHealth.getStatus()).isEqualTo(Status.UP);
+
+        // Verify Zeebe was called twice
+        verify(zeebeClient, times(2)).newTopologyRequest();
+        verify(zeebeFuture, times(2)).get(anyLong(), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void health_shouldReturnUp_withMultipleBrokers() throws Exception {
+        // Given
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(topology);
+        when(topology.getBrokers()).thenReturn(Collections.nCopies(3, brokerInfo));
+        when(topology.getClusterSize()).thenReturn(3);
+        when(topology.getPartitionsCount()).thenReturn(9);
+
+        // When
+        Health health = healthIndicator.health();
+
+        // Then
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("brokers", 3);
+        assertThat(health.getDetails()).containsEntry("clusterSize", 3);
+        assertThat(health.getDetails()).containsEntry("partitions", 9);
+    }
+
+    @Test
+    void health_shouldCacheDownStatus_whenZeebeIsDown() throws Exception {
+        // Given
+        when(zeebeClient.newTopologyRequest()).thenReturn(topologyRequestStep1);
+        when(topologyRequestStep1.send()).thenReturn(zeebeFuture);
+        when(zeebeFuture.get(anyLong(), eq(TimeUnit.SECONDS)))
+                .thenThrow(new RuntimeException("Connection failed"));
+
+        // When - First call
+        Health firstHealth = healthIndicator.health();
+
+        // When - Second call immediately after (within cache duration)
+        Health secondHealth = healthIndicator.health();
+
+        // Then
+        assertThat(firstHealth.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(secondHealth.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(firstHealth).isSameAs(secondHealth); // Same cached instance
+
+        // Verify Zeebe was only called once (down status is also cached)
+        verify(zeebeClient, times(1)).newTopologyRequest();
+        verify(zeebeFuture, times(1)).get(anyLong(), eq(TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
## Description

* Add zeebe health in application checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zeebe connectivity health check to the Channel connector health endpoint.
  * Health check now includes caching and a configurable timeout.

* **Updates**
  * Version bumped to 1.3.3-mifos-1.5.4.
  * New configuration defaults and endpoints: auth expiry buffer, transaction request endpoint, and reorganized liveness/readiness health settings with detailed reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->