### PR TITLE
chore: bump version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 
+## OAF Version 1.3.5-mifos-1.5.4
+        * [CP-3931] - Default to OAF when country-specific login credentials for Ops App are missing
+
 ## OAF Version 1.3.4-mifos-1.5.4
         * [CP-3980] - Integrate Elastic APM with PH
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.logging.level=warn
-version=1.3.4-mifos-1.5.4
+version=1.3.5-mifos-1.5.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login flow to default to OAF when country-specific credentials for Ops App are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->